### PR TITLE
Split args for init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ addopts = "--basetemp=/tmp/pytest"
 
 [tool.coverage.run]
 source = ["src", "tests"]
-omit = ["tests/**/conftest.py"]
+omit = ["tests/**/conftest.py", "tests/*"]
 # For avoiding sqlite3 concurrency issues on CIFS drives:
 data_file = "/tmp/python_template/.coverage"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ exclude_also = [
     # Don't complain about missing debug-only code:
     "def __repr__",
     "if self\\.debug",
+    "if DEBUG_PRINT:",
 
     # Don't complain if tests don't hit defensive assertion code:
     "raise AssertionError",

--- a/src/python_template/utils/__init__.py
+++ b/src/python_template/utils/__init__.py
@@ -2,7 +2,9 @@
 
 from .get_unique_filename import get_unique_filename
 from .split_args_for_inits import (
+    LEFTOVERS,
     SplitInitMixin,
+    apply_split_inits,
     auto_split_init,
     split_args_for_inits_strict_kwargs,
 )

--- a/src/python_template/utils/__init__.py
+++ b/src/python_template/utils/__init__.py
@@ -1,3 +1,8 @@
 """Import package modules for direct import from package."""
 
 from .get_unique_filename import get_unique_filename
+from .split_args_for_inits import (
+    SplitInitMixin,
+    auto_split_init,
+    split_args_for_inits_strict_kwargs,
+)

--- a/src/python_template/utils/split_args_for_inits.py
+++ b/src/python_template/utils/split_args_for_inits.py
@@ -1,0 +1,205 @@
+"""This file contains utilities to split args for inits."""
+
+import dis
+import inspect
+from collections import defaultdict
+from typing import Any
+
+
+def collect_init_param_names(cls: type) -> set:
+    """Collect all __init__ param names (excluding 'self') from cls and ancestors."""
+    names: set[str] = set()
+    for base in cls.__mro__:
+        if base is object:
+            break
+        if (init := base.__dict__.get("__init__", None)) is not None:
+            sig = inspect.signature(init)
+            params = list(sig.parameters.values())[1:]  # skip 'self'
+            names.update(
+                p.name
+                for p in params
+                if p.kind in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+            )
+    return names
+
+
+def split_args_for_inits_strict_kwargs(  # pylint: disable=too-many-locals,too-complex
+    cls: type,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    stop_at: type = object,
+) -> dict[type, dict[str, Any]]:
+    """Split args/kwargs across MRO classes, and only pass **kwargs
+    to a class if it (or its parents) will actually use them.
+    """
+    remaining_args = list(args)
+    remaining_kwargs = dict(kwargs)
+    result: defaultdict[Any, dict[str, list[Any] | dict[Any, Any]]] = (
+        defaultdict(lambda: {"args": [], "kwargs": {}})
+    )
+    param_cache = {}
+
+    for base in cls.__mro__[1:]:  # Skip the class itself
+        if base is stop_at:
+            break
+        if not (init := base.__dict__.get("__init__", None)):
+            continue
+
+        sig = inspect.signature(init)
+        params = list(sig.parameters.values())[1:]
+
+        # accepts_var_positional = any(p.kind == p.VAR_POSITIONAL for p in params)
+        accepts_var_keyword = any(p.kind == p.VAR_KEYWORD for p in params)
+
+        # Bind args
+        bound_args = []
+        param_iter = (
+            p
+            for p in params
+            if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        )
+        for p in param_iter:
+            if remaining_args:
+                bound_args.append(remaining_args.pop(0))
+            else:
+                break
+
+        # Bind kwargs explicitly listed in this __init__:
+        keyword_params = {
+            p.name
+            for p in params
+            if p.kind in (p.KEYWORD_ONLY, p.POSITIONAL_OR_KEYWORD)
+        }
+        bound_kwargs = {}
+        for key in list(remaining_kwargs):
+            if key in keyword_params:
+                bound_kwargs[key] = remaining_kwargs.pop(key)
+
+        # If accepts **kwargs, only pass keys that base class (or its ancestors) can use:
+        if accepts_var_keyword:
+            if base not in param_cache:
+                param_cache[base] = collect_init_param_names(base)
+            accepted_keys = param_cache[base]
+            for key in list(remaining_kwargs):
+                if key in accepted_keys:
+                    bound_kwargs[key] = remaining_kwargs.pop(key)
+
+        result[base]["args"].extend(bound_args)  # type: ignore[union-attr]
+        result[base]["kwargs"].update(bound_kwargs)  # type: ignore[union-attr]
+
+    # if remaining_args or remaining_kwargs:
+    result["leftovers"] = {"args": remaining_args, "kwargs": remaining_kwargs}
+
+    return result
+
+
+def _find_calling_class_from_init(instance):
+    """Examine classes in MRO of `instance` to find whose `__init__` contains
+    a direct call to `apply_split_inits`.
+    """
+    apply_split_inits_name = "apply_split_inits"
+    cls = type(instance)
+    for base in cls.__mro__:
+        if base is object:
+            continue
+        if not (init := base.__dict__.get("__init__")):
+            continue
+
+        try:  # pylint: disable=too-many-try-statements
+            instructions = list(dis.get_instructions(init))
+            for instr in instructions:
+                if (
+                    instr.opname in set("LOAD_GLOBAL", "LOAD_METHOD")
+                    and instr.argval == apply_split_inits_name
+                ):
+                    return base
+        except TypeError:
+            continue  # Skip builtins or non-Python functions
+    return None
+
+
+def apply_split_inits(self, cls=None, args=(), kwargs=None, skip_class=None):
+    """Call __init__ of all base classes using split argument mapping."""
+    cls = cls or type(self)
+    kwargs = kwargs or {}
+    # print(f"\n[apply_split_inits] Called from class: {_find_calling_class_from_init(self)}")
+    # print(f"\n[apply_split_inits] Running for class: {cls.__name__}")
+    # Automatically detect skip class as the defining class of apply_split_inits:
+    if skip_class is None:
+        skip_class = _find_calling_class_from_init(
+            self
+        )  #     print(f"[apply_split_inits] Auto-detected skip_class as: {skip_class.__name__}")
+    split = split_args_for_inits_strict_kwargs(cls, args, kwargs)
+    seen = set()
+    for base in cls.__mro__[1:]:
+        if base in (object,) or base in seen:
+            continue
+        if base is skip_class:
+            # print(f"[apply_split_inits] Skipping class {base.__name__}")
+            continue
+        seen.add(base)
+        if base in split:
+            base_args = split[base]["args"]
+            base_kwargs = split[base]["kwargs"]
+            # print(f"[apply_split_inits] Calling __init__ of {base.__name__} with:")
+            # print(f"    args: {base_args}")
+            # print(f"    kwargs: {base_kwargs}")
+            if hasattr(base, "__init__"):
+                try:
+                    # base.__init__(self, *base_args, **base_kwargs)
+                    # super(base, self).__init__(self, *base_args, **base_kwargs)
+                    super(base, self).__init__(*base_args, **base_kwargs)
+                except TypeError:
+                    # print(f"[Warning] Skipped {base.__name__} due to: {e}")
+                    # continue
+                    # print(f"[apply_split_inits] TypeError using super() for {base.__name__}: {e}")
+                    # print(f"[apply_split_inits] Falling back to direct call for {base.__name__}")
+                    # Fall back to direct init in edge cases:
+                    base.__init__(  # pylint: disable=unnecessary-dunder-call
+                        self, *base_args, **base_kwargs
+                    )
+    self._init_leftovers = split.get(  # pylint: disable=protected-access
+        "leftovers", {"args": [], "kwargs": {}}
+    )
+    # print(f"[apply_split_inits] Leftovers set to: {self._init_leftovers}")
+    return self._init_leftovers  # pylint: disable=protected-access
+
+
+class SplitInitMixin:  # pylint: disable=too-few-public-methods
+    """A mixin class to be used for automatically splitting args across inits.
+
+    Usage example:
+    class Child(SplitInitMixin, Parent1, Parent2):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # Use self._init_leftovers if needed
+    """
+
+    def __init__(self, *args, **kwargs):
+        """New init for the class."""
+        apply_split_inits(
+            self, cls=type(self), args=args, kwargs=kwargs
+        )  # , skip_class=SplitInitMixin)
+
+
+def auto_split_init(cls):
+    """A decorator to be used for automatically splitting args across inits.
+
+    Usage example:
+    @auto_split_init
+    class Child(Parent1, Parent2):
+        def __init__(self, *args, **kwargs):
+            # self._init_leftovers is available if needed
+            print("Child custom init logic")
+    """
+    original_init = cls.__init__
+
+    def wrapped_init(self, *args, **kwargs):
+        """New init for the wrapped class."""
+        leftovers = apply_split_inits(self, type(self), args, kwargs)
+        original_init(
+            self, *leftovers.get("args", []), **leftovers.get("kwargs", {})
+        )
+
+    cls.__init__ = wrapped_init
+    return cls

--- a/src/python_template/utils/split_args_for_inits.py
+++ b/src/python_template/utils/split_args_for_inits.py
@@ -183,13 +183,13 @@ def apply_split_inits(  # pylint: disable=too-complex,too-many-branches
         print(f"\n[apply_split_inits] Running for class: {cls.__name__}")
     # Automatically detect skip class as the defining class of apply_split_inits:
     if skip_class is None:
-        skip_class = _find_calling_class_from_init(self)
-        if DEBUG_PRINTS:
-            if skip_class is None:
+        if (skip_class := _find_calling_class_from_init(self)) is None:
+            if DEBUG_PRINTS:
                 print(
                     "[apply_split_inits] Warning: Failed to auto-detect skip_class."
                 )
-            else:
+        else:  # pylint: disable=else-if-used,confusing-consecutive-elif
+            if DEBUG_PRINTS:  # pylint: disable=confusing-consecutive-elif
                 print(
                     f"[apply_split_inits] Auto-detected skip_class as: {skip_class.__name__}"
                 )

--- a/src/python_template/utils/split_args_for_inits.py
+++ b/src/python_template/utils/split_args_for_inits.py
@@ -3,9 +3,10 @@
 import dis
 import inspect
 from collections import defaultdict
-from typing import Any
+from typing import Any, get_type_hints
 
 DEBUG_PRINTS = True
+LEFTOVERS = "leftovers"
 
 
 def collect_init_param_names(cls: type) -> set:
@@ -25,11 +26,13 @@ def collect_init_param_names(cls: type) -> set:
     return names
 
 
-def split_args_for_inits_strict_kwargs(  # pylint: disable=too-many-locals,too-complex,too-many-branches
+def split_args_for_inits_strict_kwargs(  # pylint: disable=too-many-locals,too-complex,too-many-branches,too-many-arguments
     cls: type,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
     stop_at: type = object,
+    enable_type_heuristics: bool = False,
+    enable_dis_bytecode_scan: bool = False,
 ) -> dict[type, dict[str, Any]]:
     """Split args/kwargs across MRO classes, and only pass **kwargs
     to a class if it (or its parents) will actually use them.
@@ -59,6 +62,20 @@ def split_args_for_inits_strict_kwargs(  # pylint: disable=too-many-locals,too-c
                 self, *self.split[Parent2]["args"], **self.split[Parent2]["kwargs"]
             )
             self._init_leftovers = self.split["leftovers"]
+
+    Args:
+        cls (type): The class type (e.g., "type(self)").
+        args (tuple): Any args passed to the instance being instantiated.
+        kwargs (dict[str, Any]): Any kwargs passed to the instance being instantiated.
+        stop_at (type): At which class to stop the hierarchy search. Defaults to object.
+        enable_type_heuristics (bool): whether to use type hint resolution. Defaults
+            to False.
+        enable_dis_bytecode_scan (bool): whether to inspect bytecode for kwargs.get.
+            Defaults to False.
+
+    Returns:
+        defaultDict[Any, dict[str, list[Any] | dict[Any, Any]]]: The dict (by class type)
+            used to indicate to which direct parent class to pass which args and kwargs.
     """
     remaining_args = list(args)
     remaining_kwargs = dict(kwargs)
@@ -71,7 +88,8 @@ def split_args_for_inits_strict_kwargs(  # pylint: disable=too-many-locals,too-c
     )
     param_cache = {}
 
-    for base in cls.__mro__[1:]:  # Skip the class itself
+    # for base in cls.__mro__[1:]:  # Skip the class itself
+    for base in cls.__bases__:  # Only look at the bases of this class.
         if base is stop_at:
             break
         if not (init := base.__dict__.get("__init__", None)):
@@ -87,6 +105,7 @@ def split_args_for_inits_strict_kwargs(  # pylint: disable=too-many-locals,too-c
         bound_args = []
         bound_kwargs = {}
         params_assigned_positionally = []
+        # 1. Route positional args:
         param_iter = (
             p
             for p in params
@@ -102,7 +121,7 @@ def split_args_for_inits_strict_kwargs(  # pylint: disable=too-many-locals,too-c
                 # bound_args.append(remaining_kwargs.pop(p.name))
             else:
                 break
-
+        # 2. Route kwargs:
         # Bind kwargs explicitly listed in this __init__:
         keyword_params = {
             p.name
@@ -131,10 +150,297 @@ def split_args_for_inits_strict_kwargs(  # pylint: disable=too-many-locals,too-c
         result[base]["args"].extend(bound_args)  # type: ignore[union-attr]
         result[base]["kwargs"].update(bound_kwargs)  # type: ignore[union-attr]
 
+    # 3. Use heuristics to route ambiguous leftovers:
+    if enable_type_heuristics:
+        apply_type_heuristic_routing(cls, remaining_kwargs, result, stop_at)
+
+    if enable_dis_bytecode_scan:
+        apply_dis_bytecode_routing(cls, remaining_kwargs, result, stop_at)
+
+    # 4. Use per-branch safe `**kwargs` inference:
+    safe_receivers = find_safe_kwargs_targets(cls)
+    for base in safe_receivers:
+        # for k in list(remaining_kwargs):
+        for k, v in remaining_kwargs.items():
+            # Pass leftovers to first safe_reciever:
+            # result[base][k] = remaining_kwargs.pop(k)
+            # Pass leftovers to all safe_recievers:
+            result[base]["kwargs"][k] = v  # type: ignore[call-overload]
+
     # if remaining_args or remaining_kwargs:
     result["leftovers"] = {"args": remaining_args, "kwargs": remaining_kwargs}
 
     return result
+
+
+def get_mro_kwarg_info(cls):
+    """Get kwarg ifno from the MRO."""
+    mro = cls.mro()
+    paraminfo = {}
+    for base in mro:
+        sig = inspect.signature(base.__init__)
+        accepted = {
+            name
+            for name, param in sig.parameters.items()
+            if name != "self"  # pylint: disable=magic-value-comparison
+            and param.kind in (param.KEYWORD_ONLY, param.POSITIONAL_OR_KEYWORD)
+        }
+        accepts_var_kw = any(
+            p.kind == p.VAR_KEYWORD for p in sig.parameters.values()
+        )
+        paraminfo[base] = (accepted, accepts_var_kw)
+    return paraminfo
+
+
+def apply_type_heuristic_routing(
+    cls, remaining_kwargs, routing, stop_at=object
+):
+    """Route kwargs based on parameter types."""
+    paraminfo = get_mro_kwarg_info(cls)
+    for base in cls.__bases__:
+        current = base
+        # for base, (accepted, _) in paraminfo.items():
+        while current != stop_at:  # pylint: disable=while-used
+            (accepted, _) = paraminfo.get(current, (set(), False))
+            type_hints = get_type_hints(base.__init__)
+            for name, val in list(remaining_kwargs.items()):
+                if name in accepted and name in type_hints:
+                    hint = type_hints[name]
+                    if isinstance(val, hint):
+                        routing[base]["kwargs"][name] = remaining_kwargs.pop(
+                            name
+                        )
+            current = current.__base__
+
+
+def apply_dis_bytecode_routing(  # pylint: disable=too-many-nested-blocks
+    cls, remaining_kwargs, routing, stop_at=object
+):
+    """Route kwargs if init function internally uses them."""
+    # paraminfo = get_mro_kwarg_info(cls)
+    # for base in paraminfo:
+    for base in cls.__bases__:
+        current = base
+        while current != stop_at:  # pylint: disable=while-used
+            try:  # pylint: disable=too-many-try-statements
+                func = base.__init__
+                # code = func.__code__
+                for instr in dis.get_instructions(func):
+                    if (
+                        instr.opname  # pylint: disable=magic-value-comparison
+                        == "LOAD_CONST"
+                        and isinstance(instr.argval, str)
+                    ):
+                        if (key := instr.argval) in remaining_kwargs:
+                            routing[base]["kwargs"][key] = (
+                                remaining_kwargs.pop(key)
+                            )
+            except Exception:  # pylint: disable=broad-exception-caught
+                # continue
+                pass
+            current = current.__base__
+
+
+def find_safe_kwargs_targets(cls):
+    """For each direct base class of `cls`, follow its MRO path down and ensure all accept **kwargs.
+    Return those safe to receive leftover kwargs.
+    """
+    paraminfo = get_mro_kwarg_info(cls)
+    safe_bases = set()
+    for base in cls.__bases__:
+        current = base
+        path_safe = True
+        while current != object:  # pylint: disable=while-used
+            _, accepts_var_kw = paraminfo.get(current, (set(), False))
+            if DEBUG_PRINTS:
+                print(f"Current: {current.__name__}")
+            if not accepts_var_kw:
+                if DEBUG_PRINTS:
+                    print("  --> Not safe!")
+                path_safe = False
+                break
+            current = current.__base__
+        if path_safe:
+            if DEBUG_PRINTS:
+                print("  --> Safe!")
+            safe_bases.add(base)
+    return safe_bases
+
+
+def share_missing_params_across_parents(
+    split: dict[type, dict[str, Any]], stop_at=object
+) -> None:
+    """For each parent class in the split, check if it is missing any required parameters
+    (positional or keyword) and try to fill them in by copying from other parent's args/kwargs.
+    """
+    # # This is not necessary. We can just use split directly.
+    # # Build param sources from other parents
+    # param_sources = defaultdict(list)
+    # for parent, data in split.items():
+    #     for k, v in zip(data.get("sig_params", []), data["args"]):
+    #         param_sources[k.name].append((parent, v))
+    #     for k, v in data["kwargs"].items():
+    #         param_sources[k].append((parent, v))
+
+    # Now check for missing parameters in each parent:
+    for parent, data in split.items():
+        if parent == LEFTOVERS:
+            continue
+        required_params = []
+        # if hasattr(parent, "__init__"):
+        #     sig = inspect.signature(parent.__init__)
+        #     required_params.extend(
+        #         [
+        #             p.name for p in sig.parameters.values()
+        #             if p.name != 'self'
+        #             and p.kind in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+        #             # We don't need this restriction; do it even if there is a default value:
+        #             # and p.default is p.empty
+        #         ]
+        #     )
+        current = parent
+        while current != stop_at:  # pylint: disable=while-used
+            if hasattr(current, "__init__"):
+                sig = inspect.signature(current.__init__)  # type: ignore[misc]
+                required_params.extend(
+                    [
+                        p.name
+                        for p in sig.parameters.values()
+                        if p.name  # pylint: disable=magic-value-comparison
+                        != "self"
+                        # and p.kind in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+                        # We don't need this restriction; do it even if there is a default value:
+                        # and p.default is p.empty
+                    ]
+                )
+                print(f"{current.__name__}: {required_params}")
+            current = current.__base__  # type: ignore
+        for pname in required_params:
+            if pname in data["kwargs"]:
+                continue
+            # found = param_sources.get(pname, [])
+            # for source_cls, val in found:
+            for source_cls, args_dicts in split.items():
+                if (
+                    source_cls != parent
+                    and pname in split[source_cls]["kwargs"]
+                ):
+                    data["kwargs"][pname] = args_dicts["kwargs"][pname]
+                    break
+
+
+def call_init_chain_respecting_super(  # pylint: disable=too-many-locals,too-complex
+    self,
+    cls: type,
+    split: dict[type, dict[str, Any]],
+    stop_at=object,
+    skip_class=None,
+) -> None:
+    """Call init methods of super-respecting classes via `super()` chain, and manually call
+    those that don't use `super()`.
+    """
+    called = set()
+
+    # Step 1: Identify super-respecting classes:
+    # (crude guess: look at if "super" is in source)
+    super_respecting = set()
+    # for base in cls.__mro__:
+    for base in cls.__bases__:
+        if base in (object, stop_at, skip_class):
+            continue
+        # try:
+        # if hasattr(base, "__init__"):
+        #     src = inspect.getsource(base.__init__)
+        #     if "super(" in src:
+        #         super_respecting.add(base)
+        if uses_super(base):
+            super_respecting.add(base)
+        # except Exception:
+        #     pass
+
+    # Step 2: Call init for non-super-respecting classes:
+    for base in cls.__mro__:
+        if base in (object, stop_at, skip_class) or base in called:
+            continue
+        if base not in super_respecting and base in split:
+            args = split[base].get("args", [])
+            kwargs = split[base].get("kwargs", {})
+            base.__init__(self, *args, **kwargs)  # type: ignore[misc] # pylint: disable=unnecessary-dunder-call
+            called.add(base)
+
+    # Step 3: Collect args and kwargs for super-respecting chain:
+    # first_bases = []
+    chains = find_super_chains(cls)
+    first_bases = [chain[0] for chain in chains]
+    super_args: dict[type, list] = {}
+    super_kwargs: dict[type, dict] = {}
+    # super_args = []
+    # super_kwargs = {}
+    # for base in cls.__mro__:
+    #     if base in super_respecting:
+    #         # if not first_base:
+    #         #     first_base = base
+    #         # What is the correct criteria to start a new "first_base"?
+    #         if ___________:
+    #             first_bases.append(base)
+    #         super_args.extend(split[base].get("args", []))
+    #         super_kwargs.update(split[base].get("kwargs", {}))
+    #         # super(base, self).__init__(*args, **kwargs)
+    #         break
+    for chain in chains:
+        base = chain[0]
+        super_args[base] = []
+        super_kwargs[base] = {}
+        for link in chain:
+            if link in split:
+                super_args[base].extend(split[link]["args"])
+                super_kwargs[base].update(split[link]["kwargs"])
+
+    # Step 4: Begin super-respecting chain from first super-respecting class in MRO:
+    for base in first_bases:
+        if base in (skip_class,):
+            continue
+        # super(base, self).__init__(*super_args[base], **super_kwargs[base])
+        base.__init__(  # type: ignore[misc] # pylint: disable=unnecessary-dunder-call
+            self, *super_args[base], **super_kwargs[base]
+        )
+
+
+def accepts_kwargs(cls) -> bool:
+    """Determine whether a class accepts kwargs."""
+    sig = inspect.signature(cls.__init__)
+    return any(p.kind == p.VAR_KEYWORD for p in sig.parameters.values())
+
+
+def uses_super(cls) -> bool:
+    """Determine whether a clss uses super."""
+    if hasattr(cls, "__init__"):
+        src = inspect.getsource(cls.__init__)
+        if "super(" in src:  # pylint: disable=magic-value-comparison
+            return True
+    return False
+
+
+def find_super_chains(cls, stop_at=object):
+    """Find chains of super-respecting classes."""
+    mro = cls.mro()[1:]  # exclude cls itself
+    chains = []
+    current_chain = []
+
+    for c in mro:
+        # if accepts_kwargs(c) and uses_super(c):
+        #     current_chain.append(c)
+        # else:
+        #     if current_chain:
+        if c in (object, stop_at):
+            break
+        current_chain.append(c)
+        if not (accepts_kwargs(c) and uses_super(c)):
+            chains.append(list(current_chain))
+            current_chain = []
+    if current_chain:
+        chains.append(current_chain)
+    return chains
 
 
 def _find_calling_class_from_init(instance):  # pylint: disable=too-complex
@@ -178,20 +484,61 @@ def _find_calling_class_from_init(instance):  # pylint: disable=too-complex
     return None
 
 
-def apply_split_inits(  # pylint: disable=too-complex,too-many-branches
+def _find_calling_class_from_init_old(instance):  # pylint: disable=too-complex
+    """Examine classes in MRO of `instance` to find whose `__init__` contains
+    a direct call to `apply_split_inits_old`.
+    """
+    apply_split_inits_name = "apply_split_inits_old"
+    cls = type(instance)
+    for base in cls.__mro__:
+        if DEBUG_PRINTS:
+            print(
+                f"\n[_find_calling_class_from_init] Inspecting parent class: {base.__name__}"
+            )
+        if base is object:
+            if DEBUG_PRINTS:
+                print(
+                    f"\n[_find_calling_class_from_init] Found hierarchy pinnacle: {base.__name__}"
+                )
+            continue
+        if not (init := base.__dict__.get("__init__")):
+            if DEBUG_PRINTS:
+                print(
+                    f"\n[_find_calling_class_from_init] {base.__name__} has no __init__ method."
+                )
+            continue
+
+        try:  # pylint: disable=too-many-try-statements
+            instructions = list(dis.get_instructions(init))
+            for instr in instructions:
+                if (
+                    instr.opname in set(["LOAD_GLOBAL", "LOAD_METHOD"])
+                    and instr.argval == apply_split_inits_name
+                ):
+                    return base
+        except TypeError as e:
+            if DEBUG_PRINTS:
+                print(
+                    f"\n[_find_calling_class_from_init] Encountered TypeError: {e}"
+                )
+            continue  # Skip builtins or non-Python functions
+    return None
+
+
+def apply_split_inits_old(  # pylint: disable=too-complex,too-many-branches
     self, cls=None, args=(), kwargs=None, skip_class=None
 ):
     """Call __init__ of all base classes using split argument mapping."""
     cls = cls or type(self)
     kwargs = kwargs or {}
     if DEBUG_PRINTS:
-        print(
-            f"\n[apply_split_inits] Called from class: {_find_calling_class_from_init(self)}"
-        )
+        # print(
+        #     f"\n[apply_split_inits] Called from class: {_find_calling_class_from_init(self)}"
+        # )
         print(f"\n[apply_split_inits] Running for class: {cls.__name__}")
     # Automatically detect skip class as the defining class of apply_split_inits:
     if skip_class is None:
-        if (skip_class := _find_calling_class_from_init(self)) is None:
+        if (skip_class := _find_calling_class_from_init_old(self)) is None:
             if DEBUG_PRINTS:
                 print(
                     "[apply_split_inits] Warning: Failed to auto-detect skip_class."
@@ -265,7 +612,45 @@ def apply_split_inits(  # pylint: disable=too-complex,too-many-branches
     #         print(f"[apply_split_inits] TypeError in super call: {e}")
     #     raise
     self._init_leftovers = split.get(  # pylint: disable=protected-access
-        "leftovers", {"args": [], "kwargs": {}}
+        LEFTOVERS, {"args": [], "kwargs": {}}
+    )
+    if DEBUG_PRINTS:
+        print(
+            f"[apply_split_inits] Leftovers set to: {self._init_leftovers}"  # pylint: disable=protected-access
+        )
+    return self._init_leftovers  # pylint: disable=protected-access
+
+
+def apply_split_inits(self, cls=None, args=(), kwargs=None, skip_class=None):
+    """Apply the split to the parent classes, first those who don't respect super
+    and then those who do based on the MRO chainsextracted from the parent classes.
+    """
+    cls = cls or type(self)
+    kwargs = kwargs or {}
+    if DEBUG_PRINTS:
+        # print(
+        #     f"\n[apply_split_inits] Called from class: {_find_calling_class_from_init(self)}"
+        # )
+        print(f"\n[apply_split_inits] Running for class: {cls.__name__}")
+    # Automatically detect skip class as the defining class of apply_split_inits:
+    if skip_class is None:
+        if (skip_class := _find_calling_class_from_init(self)) is None:
+            if DEBUG_PRINTS:
+                print(
+                    "[apply_split_inits] Warning: Failed to auto-detect skip_class."
+                )
+        else:  # pylint: disable=else-if-used,confusing-consecutive-elif
+            if DEBUG_PRINTS:  # pylint: disable=confusing-consecutive-elif
+                print(
+                    f"[apply_split_inits] Auto-detected skip_class as: {skip_class.__name__}"
+                )
+    split = split_args_for_inits_strict_kwargs(cls, args, kwargs)
+    share_missing_params_across_parents(split, stop_at=object)
+    call_init_chain_respecting_super(
+        self, type(self), split, stop_at=object, skip_class=skip_class
+    )
+    self._init_leftovers = split.get(  # pylint: disable=protected-access
+        LEFTOVERS, {"args": [], "kwargs": {}}
     )
     if DEBUG_PRINTS:
         print(
@@ -281,6 +666,7 @@ class SplitInitMixin:  # pylint: disable=too-few-public-methods
      - If some parent class has only positional arguments and comes before another
        parent class with kwargs, the first parent may fail to initialize (whether or not it
        calls super).
+    [The following parts ay not apply anymore, using the new apply_split_inits:
      - Calling super().__init__() in apply_split_inits can skip the init methods
        for the direct parent classes, so they won't get ininialized.
      - Changing the calls in apply_split_inits from super().__init__() to
@@ -296,7 +682,7 @@ class SplitInitMixin:  # pylint: disable=too-few-public-methods
     So we can't really have all three of the following at the same time, only two:
      - Automatic argument splitting
      - Compatibility with arbitrary third-party __init__ methods
-     - Full preservation of Python's super()
+     - Full preservation of Python's super()]
 
     Usage example:
     class Child(SplitInitMixin, Parent1, Parent2):

--- a/tests/test_utils/conftest.py
+++ b/tests/test_utils/conftest.py
@@ -9,6 +9,10 @@ from pathlib import Path
 
 import pytest
 
+from python_template.utils.split_args_for_inits import (
+    split_args_for_inits_strict_kwargs,
+)
+
 
 @pytest.fixture
 def temp_dir():
@@ -30,3 +34,29 @@ def temp_dir():
             pass  # Last resort: ignore if still fails
 
     shutil.rmtree(dir_path, onerror=onerror)
+
+
+@pytest.fixture
+def split_args():
+    """Wrapper fixture for split_args_for_inits_strict_kwargs."""
+    # from split_module import split_args_for_inits_strict_kwargs
+    return lambda *args, **kwargs: split_args_for_inits_strict_kwargs(  # pylint:disable=unnecessary-lambda
+        *args, **kwargs
+    )
+
+
+@pytest.fixture
+def class_wrapper():
+    """Wrapper fixture for classes."""
+
+    def _class_wrapper(base_class):
+        """Construct a wrapper class around base_class."""
+
+        class ClassWrapper(
+            base_class
+        ):  # pylint: disable=too-few-public-methods
+            """A wrapper class around base_class."""
+
+        return ClassWrapper
+
+    return _class_wrapper

--- a/tests/test_utils/test_split_args_for_inits.py
+++ b/tests/test_utils/test_split_args_for_inits.py
@@ -10,13 +10,14 @@ from python_template.utils import (
     auto_split_init,
     split_args_for_inits_strict_kwargs,
 )
-from python_template.utils.split_args_for_inits import (  # pylint: disable=unused-import
+
+# _find_calling_class_from_init_old,; apply_split_inits_old,
+from python_template.utils.split_args_for_inits import (  # pylint: disable=unused-import;
     _find_calling_class_from_init,
-    _find_calling_class_from_init_old,
-    apply_split_inits_old,
     call_init_chain_respecting_super,
     find_safe_kwargs_targets,
     share_missing_params_across_parents,
+    uses_super,
 )
 
 
@@ -128,166 +129,166 @@ class Test_FullTests:  # pylint:disable=invalid-name
         # assert d.split[LEFTOVERS]["kwargs"]["extra"] == extra
 
 
-class Test__find_calling_class_from_init_old:  # pylint:disable=invalid-name
-    """Tests for _find_calling_class_from_init_old."""
+# class Test__find_calling_class_from_init_old:  # pylint:disable=invalid-name
+#     """Tests for _find_calling_class_from_init_old."""
 
-    class BuiltinWrapper(
-        builtins.int
-    ):  # pylint: disable=too-few-public-methods
-        """Wrapper for a builtin class."""
+#     class BuiltinWrapper(
+#         builtins.int
+#     ):  # pylint: disable=too-few-public-methods
+#         """Wrapper for a builtin class."""
 
-    class DummyWithApplyOld:  # pylint: disable=too-few-public-methods
-        """Dummy class using the apply_split_inits method."""
+#     class DummyWithApplyOld:  # pylint: disable=too-few-public-methods
+#         """Dummy class using the apply_split_inits method."""
 
-        def __init__(self, *args, **kwargs):
-            apply_split_inits_old(self, args=args, kwargs=kwargs)
+#         def __init__(self, *args, **kwargs):
+#             apply_split_inits_old(self, args=args, kwargs=kwargs)
 
-    class M(SplitInitMixin):  # pylint: disable=too-few-public-methods
-        """Class inheriting SplitInitMixin and calling apply_split_inits."""
+#     class M(SplitInitMixin):  # pylint: disable=too-few-public-methods
+#         """Class inheriting SplitInitMixin and calling apply_split_inits."""
 
-        def __init__(self):  # pylint: disable=super-init-not-called
-            apply_split_inits_old(self)
+#         def __init__(self):  # pylint: disable=super-init-not-called
+#             apply_split_inits_old(self)
 
-    class NoInit:  # pylint: disable=too-few-public-methods
-        """Class with no init method."""
+#     class NoInit:  # pylint: disable=too-few-public-methods
+#         """Class with no init method."""
 
-    def test_find_calling_class_success(self):
-        """Test ensuring _find_calling_class succeeds."""
-        dummy = self.DummyWithApplyOld()
-        cls = _find_calling_class_from_init_old(dummy)
-        assert cls is self.DummyWithApplyOld
+#     def test_find_calling_class_success(self):
+#         """Test ensuring _find_calling_class succeeds."""
+#         dummy = self.DummyWithApplyOld()
+#         cls = _find_calling_class_from_init_old(dummy)
+#         assert cls is self.DummyWithApplyOld
 
-    def test_find_calling_class_skips_no_init(self):
-        """Test: Class with no init"""
-        obj = self.NoInit()
-        assert _find_calling_class_from_init_old(obj) is None
+#     def test_find_calling_class_skips_no_init(self):
+#         """Test: Class with no init"""
+#         obj = self.NoInit()
+#         assert _find_calling_class_from_init_old(obj) is None
 
-    def test_find_calling_class_handles_typeerror(self):
-        """Test: Class with non-introspectable init (simulate TypeError)"""
-        # Simulate with a built-in that raises TypeError on inspection
-        obj = self.BuiltinWrapper()
-        assert _find_calling_class_from_init_old(obj) is None
+#     def test_find_calling_class_handles_typeerror(self):
+#         """Test: Class with non-introspectable init (simulate TypeError)"""
+#         # Simulate with a built-in that raises TypeError on inspection
+#         obj = self.BuiltinWrapper()
+#         assert _find_calling_class_from_init_old(obj) is None
 
-    def test_find_calling_class_positive(self):
-        """Test: Positive detection (init calls apply_split_inits)."""
-        obj = self.M()
-        assert _find_calling_class_from_init_old(obj) == self.M
+#     def test_find_calling_class_positive(self):
+#         """Test: Positive detection (init calls apply_split_inits)."""
+#         obj = self.M()
+#         assert _find_calling_class_from_init_old(obj) == self.M
 
 
-class Test_apply_split_inits_old:  # pylint:disable=invalid-name
-    """Tests for apply_split_inits_old."""
+# class Test_apply_split_inits_old:  # pylint:disable=invalid-name
+#     """Tests for apply_split_inits_old."""
 
-    class AcceptsAll:  # pylint: disable=too-few-public-methods
-        """Class that accepts all kwargs."""
+#     class AcceptsAll:  # pylint: disable=too-few-public-methods
+#         """Class that accepts all kwargs."""
 
-        def __init__(self, **kwargs):
-            pass
+#         def __init__(self, **kwargs):
+#             pass
 
-    class AcceptsAllDummy(
-        AcceptsAll
-    ):  # pylint: disable=too-few-public-methods
-        """Wrapper class for AcceptsAll class."""
+#     class AcceptsAllDummy(
+#         AcceptsAll
+#     ):  # pylint: disable=too-few-public-methods
+#         """Wrapper class for AcceptsAll class."""
 
-    class BuiltinTypeClass:  # pylint: disable=too-few-public-methods
-        """Class that should raise TypeError in dis.get_instructions."""
+#     class BuiltinTypeClass:  # pylint: disable=too-few-public-methods
+#         """Class that should raise TypeError in dis.get_instructions."""
 
-        __init__ = object.__init__
+#         __init__ = object.__init__
 
-    class Skip(SplitInitMixin):  # pylint: disable=too-few-public-methods
-        """Class with a defined skip class."""
+#     class Skip(SplitInitMixin):  # pylint: disable=too-few-public-methods
+#         """Class with a defined skip class."""
 
-        def __init__(self):  # pylint: disable=super-init-not-called
-            apply_split_inits_old(self, skip_class=type(self))
+#         def __init__(self):  # pylint: disable=super-init-not-called
+#             apply_split_inits_old(self, skip_class=type(self))
 
-    def test_apply_split_inits_manual_skip(self):
-        """Test: Skip class manually"""
-        obj = self.Skip()
-        assert hasattr(obj, "_init_leftovers")
+#     def test_apply_split_inits_manual_skip(self):
+#         """Test: Skip class manually"""
+#         obj = self.Skip()
+#         assert hasattr(obj, "_init_leftovers")
 
-    # Line tests: raise TypeError handling
-    def test_split_args_with_var_kwargs(self):
-        """Test: Class with **kwargs"""
-        result = split_args_for_inits_strict_kwargs(
-            self.AcceptsAllDummy, [], {"z": 1}
-        )
-        assert result[self.AcceptsAll]["kwargs"] == {"z": 1}
-        assert result[LEFTOVERS]["kwargs"] == {"z": 1}
+#     # Line tests: raise TypeError handling
+#     def test_split_args_with_var_kwargs(self):
+#         """Test: Class with **kwargs"""
+#         result = split_args_for_inits_strict_kwargs(
+#             self.AcceptsAllDummy, [], {"z": 1}
+#         )
+#         assert result[self.AcceptsAll]["kwargs"] == {"z": 1}
+#         assert result[LEFTOVERS]["kwargs"] == {"z": 1}
 
-    def test_find_calling_class_typeerror_branch(self):
-        """Test that should raise TypeError and hit that branch."""
-        instance = self.BuiltinTypeClass()
-        result = _find_calling_class_from_init_old(instance)
-        assert result is None
+#     def test_find_calling_class_typeerror_branch(self):
+#         """Test that should raise TypeError and hit that branch."""
+#         instance = self.BuiltinTypeClass()
+#         result = _find_calling_class_from_init_old(instance)
+#         assert result is None
 
-    # Line test: if skip_class is None: (which means _find_calling_class_from_init failed)
-    def test_apply_split_inits_old_skip_class_none_branch(self, monkeypatch):
-        """Test forcing the _find_calling_class_from_init to fail."""
+#     # Line test: if skip_class is None: (which means _find_calling_class_from_init failed)
+#     def test_apply_split_inits_old_skip_class_none_branch(self, monkeypatch):
+#         """Test forcing the _find_calling_class_from_init to fail."""
 
-        class X:  # pylint: disable=too-few-public-methods
-            """Class with one positional arg."""
+#         class X:  # pylint: disable=too-few-public-methods
+#             """Class with one positional arg."""
 
-            def __init__(self, foo):  # pylint: disable=disallowed-name
-                self.foo = foo  # pylint: disable=disallowed-name
+#             def __init__(self, foo):  # pylint: disable=disallowed-name
+#                 self.foo = foo  # pylint: disable=disallowed-name
 
-        class Y:  # pylint: disable=too-few-public-methods
-            """Class with one kwarg."""
+#         class Y:  # pylint: disable=too-few-public-methods
+#             """Class with one kwarg."""
 
-            def __init__(self, bar=2):  # pylint: disable=disallowed-name
-                self.bar = bar  # pylint: disable=disallowed-name
+#             def __init__(self, bar=2):  # pylint: disable=disallowed-name
+#                 self.bar = bar  # pylint: disable=disallowed-name
 
-        class Z(X, Y):  # pylint: disable=too-few-public-methods
-            """Class to inherit two other classes."""
+#         class Z(X, Y):  # pylint: disable=too-few-public-methods
+#             """Class to inherit two other classes."""
 
-            def __init__(
-                self, *args, **kwargs
-            ):  # pylint: disable=super-init-not-called
-                apply_split_inits_old(self, args=args, kwargs=kwargs)
+#             def __init__(
+#                 self, *args, **kwargs
+#             ):  # pylint: disable=super-init-not-called
+#                 apply_split_inits_old(self, args=args, kwargs=kwargs)
 
-        # Force _find_calling_class_from_init to raise TypeError
-        monkeypatch.setattr(
-            "python_template.utils.split_args_for_inits._find_calling_class_from_init",
-            # lambda self: (_ for _ in ()).throw(TypeError("mocked")),
-            lambda self: None,
-        )
+#         # Force _find_calling_class_from_init to raise TypeError
+#         monkeypatch.setattr(
+#             "python_template.utils.split_args_for_inits._find_calling_class_from_init",
+#             # lambda self: (_ for _ in ()).throw(TypeError("mocked")),
+#             lambda self: None,
+#         )
 
-        z = Z(1, bar=5)
-        assert hasattr(z, "bar")
+#         z = Z(1, bar=5)
+#         assert hasattr(z, "bar")
 
-    # Line test: Except exception (after already excepting TypeError earlier)
-    def test_apply_split_inits_old_direct_call_fallback(self, monkeypatch):
-        """Test: super fails, then base.__init__ raises an exception."""
-        # Patch super() to raise TypeError for test coverage
-        original_super = super
+#     # Line test: Except exception (after already excepting TypeError earlier)
+#     def test_apply_split_inits_old_direct_call_fallback(self, monkeypatch):
+#         """Test: super fails, then base.__init__ raises an exception."""
+#         # Patch super() to raise TypeError for test coverage
+#         original_super = super
 
-        class MockSuper:  # pylint: disable=too-few-public-methods
-            """A class to mock the super function."""
+#         class MockSuper:  # pylint: disable=too-few-public-methods
+#             """A class to mock the super function."""
 
-            def __init__(self, base, obj):
-                raise TypeError("force fallback")
+#             def __init__(self, base, obj):
+#                 raise TypeError("force fallback")
 
-        monkeypatch.setattr("builtins.super", MockSuper)
+#         monkeypatch.setattr("builtins.super", MockSuper)
 
-        class Bar:  # pylint:disable=too-few-public-methods
-            """Class whose base.__init__ should raise an exception."""
+#         class Bar:  # pylint:disable=too-few-public-methods
+#             """Class whose base.__init__ should raise an exception."""
 
-            def __init__(self, bar):  # pylint: disable=disallowed-name
-                self.bar = bar  # pylint: disable=disallowed-name
-                # This makes it raise a TypeError while doing the base.__init__:
-                raise TypeError
+#             def __init__(self, bar):  # pylint: disable=disallowed-name
+#                 self.bar = bar  # pylint: disable=disallowed-name
+#                 # This makes it raise a TypeError while doing the base.__init__:
+#                 raise TypeError
 
-        class FailSuper(Bar):  # pylint: disable=too-few-public-methods
-            """Class that should fail super ad fall back to base.__init__"""
+#         class FailSuper(Bar):  # pylint: disable=too-few-public-methods
+#             """Class that should fail super ad fall back to base.__init__"""
 
-            def __init__(
-                self, *args, **kwargs
-            ):  # pylint: disable=super-init-not-called
-                apply_split_inits_old(self, args=args, kwargs=kwargs)
+#             def __init__(
+#                 self, *args, **kwargs
+#             ):  # pylint: disable=super-init-not-called
+#                 apply_split_inits_old(self, args=args, kwargs=kwargs)
 
-        fortytwo = 42
-        f = FailSuper(bar=fortytwo)
-        assert f.bar == fortytwo
+#         fortytwo = 42
+#         f = FailSuper(bar=fortytwo)
+#         assert f.bar == fortytwo
 
-        monkeypatch.setattr("builtins.super", original_super)  # Restore
+#         monkeypatch.setattr("builtins.super", original_super)  # Restore
 
 
 class Test__find_calling_class_from_init:  # pylint:disable=invalid-name,too-few-public-methods
@@ -308,8 +309,90 @@ class Test__find_calling_class_from_init:  # pylint:disable=invalid-name,too-few
         assert result[LEFTOVERS]["args"] == [1]
         assert result[LEFTOVERS]["kwargs"] == {"x": 2}
 
+    class DummyWithApply:  # pylint: disable=too-few-public-methods
+        """Dummy class using the apply_split_inits method."""
 
-class Test_split_args_for_inits:  # pylint:disable=invalid-name
+        def __init__(self, *args, **kwargs):
+            apply_split_inits(self, args=args, kwargs=kwargs)
+
+    def test_find_calling_class_success(self):
+        """Test ensuring _find_calling_class succeeds."""
+        dummy = self.DummyWithApply()
+        cls = _find_calling_class_from_init(dummy)
+        assert cls is self.DummyWithApply
+
+    class NoInit:  # pylint: disable=too-few-public-methods
+        """Class with no init method."""
+
+    def test_find_calling_class_skips_no_init(self):
+        """Test: Class with no init"""
+        obj = self.NoInit()
+        assert _find_calling_class_from_init(obj) is None
+
+    class BuiltinWrapper(
+        builtins.int
+    ):  # pylint: disable=too-few-public-methods
+        """Wrapper for a builtin class."""
+
+    def test_find_calling_class_handles_typeerror(self):
+        """Test: Class with non-introspectable init (simulate TypeError)"""
+        # Simulate with a built-in that raises TypeError on inspection
+        obj = self.BuiltinWrapper()
+        assert _find_calling_class_from_init(obj) is None
+
+    # class M(SplitInitMixin):  # pylint: disable=too-few-public-methods
+    class M:  # pylint: disable=too-few-public-methods
+        """Class inheriting SplitInitMixin and calling apply_split_inits."""
+
+        def __init__(self):  # pylint: disable=super-init-not-called
+            apply_split_inits(self)
+            # super().__init__()
+
+    def test_find_calling_class_positive(self):
+        """Test: Positive detection (init calls apply_split_inits)."""
+        obj = self.M()
+        assert _find_calling_class_from_init(obj) == self.M
+
+
+class Test_apply_split_inits:  # pylint: disable=invalid-name
+    """Tests for apply_split_inits."""
+
+    # Line test: if skip_class is None: (which means _find_calling_class_from_init failed)
+    def test_apply_split_inits_skip_class_none_branch(self, monkeypatch):
+        """Test forcing the _find_calling_class_from_init to fail."""
+
+        class X:  # pylint: disable=too-few-public-methods
+            """Class with one positional arg."""
+
+            def __init__(self, foo):  # pylint: disable=disallowed-name
+                self.foo = foo  # pylint: disable=disallowed-name
+
+        class Y:  # pylint: disable=too-few-public-methods
+            """Class with one kwarg."""
+
+            def __init__(self, bar=2):  # pylint: disable=disallowed-name
+                self.bar = bar  # pylint: disable=disallowed-name
+
+        class Z(X, Y):  # pylint: disable=too-few-public-methods
+            """Class to inherit two other classes."""
+
+            def __init__(
+                self, *args, **kwargs
+            ):  # pylint: disable=super-init-not-called
+                apply_split_inits(self, args=args, kwargs=kwargs)
+
+        # Force _find_calling_class_from_init to raise TypeError
+        monkeypatch.setattr(
+            "python_template.utils.split_args_for_inits._find_calling_class_from_init",
+            # lambda self: (_ for _ in ()).throw(TypeError("mocked")),
+            lambda self: None,
+        )
+
+        z = Z(1, bar=5)
+        assert hasattr(z, "bar")
+
+
+class Test_split_args_for_inits:  # pylint: disable=invalid-name
     """Tests for split_args_for_inits"""
 
     class A1:  # pylint: disable=too-few-public-methods
@@ -1184,6 +1267,10 @@ class Test_Alphabet:  # pylint: disable=invalid-name
     l = 12
     m = 13
     n = 14
+
+    def test_c(self):
+        """Tests that uses_super returns True for class C."""
+        assert uses_super(self.C)
 
     def test_d(self):
         """Tests that kwargs are correctly passed to correct kwargs in

--- a/tests/test_utils/test_split_args_for_inits.py
+++ b/tests/test_utils/test_split_args_for_inits.py
@@ -4,763 +4,775 @@ in the split_args_for_inits module."""
 import builtins
 
 from python_template.utils import (
+    LEFTOVERS,
     SplitInitMixin,
+    apply_split_inits,
     auto_split_init,
     split_args_for_inits_strict_kwargs,
 )
-from python_template.utils.split_args_for_inits import (
+from python_template.utils.split_args_for_inits import (  # pylint: disable=unused-import
+    _find_calling_class_from_init,
     _find_calling_class_from_init_old,
     apply_split_inits_old,
 )
 
-# Classes for tests:
 
-
-class A:  # pylint: disable=too-few-public-methods
-    """Test class A."""
-
-    def __init__(self, a1, a2=0, **kwargs):
-        print(f"A init: a1={a1}, a2={a2}, kwargs={kwargs}")
-        self.a1 = a1
-        self.a2 = a2
-
-
-class A1:  # pylint: disable=too-few-public-methods
-    """Class accepting one positional arg."""
-
-    def __init__(self, a):
-        self._a = a
-        super().__init__()
-
-
-class AcceptsAll:  # pylint: disable=too-few-public-methods
-    """Class that accepts all kwargs."""
-
-    def __init__(self, **kwargs):
-        pass
-
-
-class AcceptsAllDummy(AcceptsAll):  # pylint: disable=too-few-public-methods
-    """Wrapper class for AcceptsAll class."""
-
-
-class AKeywords:  # pylint: disable=too-few-public-methods
-    """A class with optional positional args and one kwarg."""
-
-    def __init__(self, *, a_kwarg):
-        self.a_kwarg = a_kwarg
-
-
-class B:  # pylint: disable=too-few-public-methods
-    """Test class B."""
-
-    def __init__(self, b1, b2=0):
-        print(f"B init: b1={b1}, b2={b2}")
-        self.b1 = b1
-        self.b2 = b2
-
-
-class B1:  # pylint: disable=too-few-public-methods
-    """Class accepting variable kwargs."""
-
-    def __init__(self, **kwargs):
-        self._b_kwargs = kwargs
-        super().__init__()
-
-
-class B2:  # pylint: disable=too-few-public-methods
-    """Class with one kwarg that accepts all kwargs."""
-
-    def __init__(self, b=0, **kwargs):
-        self.b = b
-        self.extra = kwargs.get("extra", None)
-
-
-class BStarKwargs:  # pylint: disable=too-few-public-methods
-    """Class with star kwargs."""
-
-    def __init__(self, **kwargs):
-        # self.b_seen = "bk" in kwargs
-        self.b_seen = True
-        self.bk = kwargs.get("bk", None)
-
-
-class BuiltinTypeClass:  # pylint: disable=too-few-public-methods
-    """Class that should raise TypeError in dis.get_instructions."""
-
-    __init__ = object.__init__
-
-
-class BuiltinWrapper(builtins.int):  # pylint: disable=too-few-public-methods
-    """Wrapper for a builtin class."""
-
-
-class C(SplitInitMixin, A, B):  # pylint: disable=too-few-public-methods
-    """Test class C. For use of the mixin class."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        print(
-            f"C leftovers: {self._init_leftovers}"  # pylint: disable=no-member
-        )
-
-
-class C1(SplitInitMixin, A1, B1):  # pylint: disable=too-few-public-methods
-    """Class using mixin with a parent with a positional arg and a parent with a
-    kwarg"""
-
-    def __init__(
-        self, *args, **kwargs
-    ):  # pylint: disable=useless-parent-delegation
-        # apply_split_inits(self, args, kwargs)
-        super().__init__(*args, **kwargs)
-        # SplitInitMixin.__init__(self, *args, **kwargs)
-
-
-class C2(SplitInitMixin, A1):  # pylint: disable=too-few-public-methods
-    """Class using mixin with one other parent with positional arg."""
-
-    def __init__(
-        self, *args, **kwargs
-    ):  # pylint: disable=useless-parent-delegation
-        super().__init__(*args, **kwargs)
-
-
-class C3(A1, B2):  # pylint: disable=too-few-public-methods
-    """Class calling other classes."""
-
-    def __init__(self, *args, **kwargs):
-        self.split = split_args_for_inits_strict_kwargs(
-            type(self), args, kwargs
-        )
-        A1.__init__(self, *self.split[A1]["args"], **self.split[A1]["kwargs"])
-        B2.__init__(self, *self.split[B2]["args"], **self.split[B2]["kwargs"])
-        self.leftovers = self.split["leftovers"]
-
-
-class CombinedClass(
-    AKeywords, BStarKwargs
-):  # pylint: disable=too-few-public-methods
-    """Class combining AKeywords and BStarKwargs."""
-
-    def __init__(self, *args, **kwargs):
-        self.split = split_args_for_inits_strict_kwargs(
-            type(self), args, kwargs
-        )
-        AKeywords.__init__(
-            self,
-            *self.split[AKeywords]["args"],
-            **self.split[AKeywords]["kwargs"],
-        )
-        BStarKwargs.__init__(
-            self,
-            *self.split[BStarKwargs]["args"],
-            **self.split[BStarKwargs]["kwargs"],
-        )
-        self.leftovers = self.split["leftovers"]
-
-
-@auto_split_init
-class D(A, B):  # pylint: disable=too-few-public-methods
-    """Test class D. For use of the decorator."""
-
-    def __init__(
-        self, *args, **kwargs
-    ):  # pylint: disable=super-init-not-called,unused-argument
-        print(
-            f"D leftovers: {self._init_leftovers}"  # pylint: disable=no-member
-        )
-
-
-@auto_split_init
-class D1(A1, B1):  # pylint: disable=too-few-public-methods
-    """Class using decorator."""
-
-    def __init__(
-        self, *args, **kwargs
-    ):  # pylint: disable=super-init-not-called
-        pass
-
-
-class DummyWithApplyOld:  # pylint: disable=too-few-public-methods
-    """Dummy class using the apply_split_inits method."""
-
-    def __init__(self, *args, **kwargs):
-        apply_split_inits_old(self, args=args, kwargs=kwargs)
-
-
-class E(A, B):  # pylint: disable=too-few-public-methods
-    """Test class E. For use of the function."""
-
-    def __init__(self, *args, **kwargs):
-        self.split = split_args_for_inits_strict_kwargs(
-            type(self), args, kwargs
-        )
-        A.__init__(self, *self.split[A]["args"], **self.split[A]["kwargs"])
-        B.__init__(self, *self.split[B]["args"], **self.split[B]["kwargs"])
-        print(f"E leftovers: {self.split['leftovers']}")
-
-
-class E1(A1, B1):  # pylint: disable=too-few-public-methods
-    """Test class E1. For use of the function."""
-
-    def __init__(self, *args, **kwargs):
-        self.split = split_args_for_inits_strict_kwargs(
-            type(self), args, kwargs
-        )
-        A1.__init__(self, *self.split[A1]["args"], **self.split[A1]["kwargs"])
-        B1.__init__(self, *self.split[B1]["args"], **self.split[B1]["kwargs"])
-        print(f"E leftovers: {self.split['leftovers']}")
-
-
-class Empty:  # pylint: disable=too-few-public-methods
-    """Empty class."""
-
-
-class EmptyDummy(Empty):  # pylint: disable=too-few-public-methods
-    """Wrapper class for Empty class."""
-
-
-class F:  # pylint: disable=too-few-public-methods
-    """Class with one keyword arg"""
-
-    def __init__(self, a=1):
-        pass
-
-
-class FDummy(F):  # pylint: disable=too-few-public-methods
-    """Wrapper class for F class."""
-
-
-class M(SplitInitMixin):  # pylint: disable=too-few-public-methods
-    """Class inheriting SplitInitMixin and calling apply_split_inits."""
-
-    def __init__(self):  # pylint: disable=super-init-not-called
-        apply_split_inits_old(self)
-
-
-class M1:  # pylint: disable=too-few-public-methods
-    """Class with one positional arg."""
-
-    def __init__(self, x):
-        self._x = x
-
-
-class M2:  # pylint: disable=too-few-public-methods
-    """Class with one positional arg."""
-
-    def __init__(self, y):
-        self._y = y
-
-
-class M3(SplitInitMixin, M1, M2):  # pylint: disable=too-few-public-methods
-    """Class with parent classes inheriting SplitInitMixin."""
-
-    def __init__(
-        self, *args, **kwargs
-    ):  # pylint: disable=useless-parent-delegation
-        super().__init__(*args, **kwargs)
-
-
-class NoInit:  # pylint: disable=too-few-public-methods
-    """Class with no init method."""
-
-
-class P1:  # pylint: disable=too-few-public-methods
-    """Class with one positional arg and one kwarg."""
-
-    def __init__(self, a, b=2):
-        pass
-
-
-class P1Dummy(P1):  # pylint: disable=too-few-public-methods
-    """Dummy wrapper class for P1"""
-
-
-class P2:  # pylint: disable=too-few-public-methods
-    """Class with two kwargs."""
-
-    def __init__(self, foo=None, bar=None):  # pylint: disable=disallowed-name
-        pass
-
-
-class P2Dummy(P2):  # pylint: disable=too-few-public-methods
-    """Dummy wrapper class for P2."""
-
-
-class Q(P2):  # pylint: disable=too-few-public-methods
-    """Class inheriting P2 that has its own stuff too."""
-
-    def __init__(self, q1, **kwargs):
-        self.q1 = q1
-        super().__init__(**kwargs)
-
-
-class QDummy(Q):  # pylint:disable=too-few-public-methods
-    """Wrapper class or Q."""
-
-
-class Skip(SplitInitMixin):  # pylint: disable=too-few-public-methods
-    """Class with a defined skip class."""
-
-    def __init__(self):  # pylint: disable=super-init-not-called
-        apply_split_inits_old(self, skip_class=Skip)
-
-
-# Full tests
-
-
-def test_split_args_for_inits_strict_kwargs():
-    """Tests the split_args_for_inits_strict_kwargs function."""
-    # print("\n=== Function Test ===")
-    a1 = "a"
-    b1 = "b"
-    extra = 987
-    zero = 0
-    e = E(a1=a1, b1=b1, extra=extra)
-    # === Function Test ===
-    # A init: a1=a, a2=0, kwargs={}
-    # B init: b1=b, b2=0
-    # E leftovers: {'args': [], 'kwargs': {'extra': 987}}
-    assert e.a1 == a1
-    assert e.a2 == zero
-    assert e.b1 == b1
-    assert e.b2 == zero
-    assert e.split["leftovers"]["kwargs"]["extra"] == extra
-
-
-def test_split_init_mixin():
-    """Tests the SplitInitMixin class."""
-    a1 = "foo"
-    b1 = "bar"
-    extra = 123
-    zero = 0
-    # print("\n=== Mixin Test ===")
-    c = C(a1=a1, b1=b1, extra=extra)
-    # === Mixin Test ===
-    # A init: a1=foo, a2=0, kwargs={}
-    # B init: b1=bar, b2=0
-    # C leftovers: {'args': [], 'kwargs': {'extra': 123}}
-    assert c.a1 == a1
-    assert c.a2 == zero
-    assert c.b1 == b1
-    assert c.b2 == zero
-    # assert c.split["leftovers"]["kwargs"]["extra"] == extra
-
-
-def test_auto_split_init():
-    """Tests the auto_split_init decoarator."""
-    a1 = "x"
-    b1 = "y"
-    extra = 456
-    zero = 0
-    # print("\n=== Decorator Test ===")
-    d = D(a1=a1, b1=b1, extra=extra)
-    # === Decorator Test ===
-    # A init: a1=x, a2=0, kwargs={}
-    # B init: b1=y, b2=0
-    # D leftovers: {'args': [], 'kwargs': {'extra': 456}}
-    assert d.a1 == a1
-    assert d.a2 == zero
-    assert d.b1 == b1
-    assert d.b2 == zero
-    # assert d.split["leftovers"]["kwargs"]["extra"] == extra
-
-
-# Line tests
-
-
-#  94: positive branch of if not (init := base.__dict__.get("__init__", None)):
-# This I think is covered by the test for line 149 below?
-
-
-# 114: positive branch of if remaining_args:
-def test_split_args_with_positional_args():
-    """Test: Positional argument matching (covers if remaining_args: branch)"""
-
-    args = [1]
-    kwargs = {"b": 5, "x": 42}
-    result = split_args_for_inits_strict_kwargs(P1Dummy, args, kwargs)
-    assert result[P1]["args"] == [1]
-    assert result[P1]["kwargs"] == {"b": 5}
-    assert result["leftovers"]["kwargs"] == {"x": 42}
-
-
-# 131: positive branch of if key in keyword_params:
-def test_split_args_with_kwarg_param():
-    """Test: positive branch of if key in keyword_params"""
-    a_val = 10
-    args = ()
-    kwargs = {"a": a_val}
-    result = split_args_for_inits_strict_kwargs(FDummy, args, kwargs)
-    assert result[F]["kwargs"] == kwargs
-
-
-def test_bind_kwargs_from_remaining():
-    """Test that binds kwargs from remaining (for the positive branch above)"""
-    a_kwarg = 42
-    bk = "present"
-    unused = "leftover"
-    obj = CombinedClass(a_kwarg=a_kwarg, bk=bk, unused=unused)
-    assert obj.a_kwarg == a_kwarg
-    # Beacuse of the way it is set up looking for bk in kwargs, it won't get bk.
-    # assert obj.bk == bk
-    assert obj.b_seen
-    assert obj.leftovers["kwargs"] == {"bk": bk, "unused": unused}
-
-
-# 143: positive branch of if key in accepted_keys:
-def test_split_args_with_filtered_kwargs():
-    """Test: Accepted key filtering (covers if key in accepted_keys:)"""
-    args = []
-    kwargs = {"foo": "FOO", "baz": "BAZ"}
-    result = split_args_for_inits_strict_kwargs(P2Dummy, args, kwargs)
-    assert result[P2]["kwargs"] == {"foo": "FOO"}
-    assert result["leftovers"]["kwargs"] == {"baz": "BAZ"}
-
-    kwargs["q1"] = "q1"
-    result = split_args_for_inits_strict_kwargs(QDummy, args, kwargs)
-    assert result[Q]["kwargs"] == {"q1": kwargs["q1"], "foo": kwargs["foo"]}
-    assert result[P2] == {"args": [], "kwargs": {}}
-    assert result["leftovers"] == {
-        "args": [],
-        "kwargs": {"baz": kwargs["baz"]},
-    }
-
-
-# 464: positive branches of if not (init := base.__dict__.get("__init__")):
-def test_split_args_with_no_init():
-    """Test: Class with no __init__"""
-    result = split_args_for_inits_strict_kwargs(EmptyDummy, [1], {"x": 2})
-    assert result["leftovers"]["args"] == [1]
-    assert result["leftovers"]["kwargs"] == {"x": 2}
-
-
-# 479: raise TypeError handling
-def test_split_args_with_var_kwargs():
-    """Test: Class with **kwargs"""
-    result = split_args_for_inits_strict_kwargs(AcceptsAllDummy, [], {"z": 1})
-    assert result[AcceptsAll]["kwargs"] == {"z": 1}
-    assert result["leftovers"]["kwargs"] == {"z": 1}
-
-
-def test_find_calling_class_typeerror_branch():
-    """Test that should raise TypeError and hit that branch."""
-    instance = BuiltinTypeClass()
-    result = _find_calling_class_from_init_old(instance)
-    assert result is None
-
-
-# 500: if skip_class is None: (which means _find_calling_class_from_init failed)
-def test_apply_split_inits_old_skip_class_none_branch(monkeypatch):
-    """Test forcing the _find_calling_class_from_init to fail."""
-
-    class X:  # pylint: disable=too-few-public-methods
-        """Class with one positional arg."""
-
-        def __init__(self, foo):  # pylint: disable=disallowed-name
-            self.foo = foo  # pylint: disable=disallowed-name
-
-    class Y:  # pylint: disable=too-few-public-methods
-        """Class with one kwarg."""
-
-        def __init__(self, bar=2):  # pylint: disable=disallowed-name
-            self.bar = bar  # pylint: disable=disallowed-name
-
-    class Z(X, Y):  # pylint: disable=too-few-public-methods
-        """Class to inherit two other classes."""
+class Test_FullTests:  # pylint:disable=invalid-name
+    """Tests of the full integration."""
+
+    class A:  # pylint: disable=too-few-public-methods
+        """Test class A."""
+
+        def __init__(self, a1, a2=0, **kwargs):
+            print(f"A init: a1={a1}, a2={a2}, kwargs={kwargs}")
+            self.a1 = a1
+            self.a2 = a2
+
+    class B:  # pylint: disable=too-few-public-methods
+        """Test class B."""
+
+        def __init__(self, b1, b2=0):
+            print(f"B init: b1={b1}, b2={b2}")
+            self.b1 = b1
+            self.b2 = b2
+
+    class C(SplitInitMixin, A, B):  # pylint: disable=too-few-public-methods
+        """Test class C. For use of the mixin class."""
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            print(
+                f"C leftovers: {self._init_leftovers}"  # pylint: disable=no-member
+            )
+
+    @auto_split_init
+    class D(A, B):  # pylint: disable=too-few-public-methods
+        """Test class D. For use of the decorator."""
+
+        def __init__(
+            self, *args, **kwargs
+        ):  # pylint: disable=super-init-not-called,unused-argument
+            print(
+                f"D leftovers: {self._init_leftovers}"  # pylint: disable=no-member
+            )
+
+    class E(A, B):  # pylint: disable=too-few-public-methods
+        """Test class E. For use of the function."""
 
         def __init__(
             self, *args, **kwargs
         ):  # pylint: disable=super-init-not-called
+            self.split = split_args_for_inits_strict_kwargs(
+                type(self), args, kwargs
+            )
+            # A.__init__(self, *self.split[A]["args"], **self.split[A]["kwargs"])
+            # B.__init__(self, *self.split[B]["args"], **self.split[B]["kwargs"])
+            apply_split_inits(self, type(self), args, kwargs)
+            print(f"E leftovers: {self.split['leftovers']}")
+
+    def test_split_args_for_inits_strict_kwargs(self):
+        """Tests the split_args_for_inits_strict_kwargs function."""
+        # print("\n=== Function Test ===")
+        a1 = "a"
+        b1 = "b"
+        extra = 987
+        zero = 0
+        e = self.E(a1=a1, b1=b1, extra=extra)
+        # === Function Test ===
+        # A init: a1=a, a2=0, kwargs={}
+        # B init: b1=b, b2=0
+        # E leftovers: {'args': [], 'kwargs': {'extra': 987}}
+        assert e.a1 == a1
+        assert e.a2 == zero
+        assert e.b1 == b1
+        assert e.b2 == zero
+        assert e.split[LEFTOVERS]["kwargs"]["extra"] == extra
+
+    def test_split_init_mixin(self):
+        """Tests the SplitInitMixin class."""
+        a1 = "foo"
+        b1 = "bar"
+        extra = 123
+        zero = 0
+        # print("\n=== Mixin Test ===")
+        c = self.C(a1=a1, b1=b1, extra=extra)
+        # === Mixin Test ===
+        # A init: a1=foo, a2=0, kwargs={}
+        # B init: b1=bar, b2=0
+        # C leftovers: {'args': [], 'kwargs': {'extra': 123}}
+        assert c.a1 == a1
+        assert c.a2 == zero
+        assert c.b1 == b1
+        assert c.b2 == zero
+        # assert c.split[LEFTOVERS]["kwargs"]["extra"] == extra
+
+    def test_auto_split_init(self):
+        """Tests the auto_split_init decoarator."""
+        a1 = "x"
+        b1 = "y"
+        extra = 456
+        zero = 0
+        # print("\n=== Decorator Test ===")
+        d = self.D(a1=a1, b1=b1, extra=extra)
+        # === Decorator Test ===
+        # A init: a1=x, a2=0, kwargs={}
+        # B init: b1=y, b2=0
+        # D leftovers: {'args': [], 'kwargs': {'extra': 456}}
+        assert d.a1 == a1
+        assert d.a2 == zero
+        assert d.b1 == b1
+        assert d.b2 == zero
+        # assert d.split[LEFTOVERS]["kwargs"]["extra"] == extra
+
+
+class Test__find_calling_class_from_init_old:  # pylint:disable=invalid-name
+    """Tests for _find_calling_class_from_init_old."""
+
+    class BuiltinWrapper(
+        builtins.int
+    ):  # pylint: disable=too-few-public-methods
+        """Wrapper for a builtin class."""
+
+    class DummyWithApplyOld:  # pylint: disable=too-few-public-methods
+        """Dummy class using the apply_split_inits method."""
+
+        def __init__(self, *args, **kwargs):
             apply_split_inits_old(self, args=args, kwargs=kwargs)
 
-    # Force _find_calling_class_from_init to raise TypeError
-    monkeypatch.setattr(
-        "python_template.utils.split_args_for_inits._find_calling_class_from_init",
-        # lambda self: (_ for _ in ()).throw(TypeError("mocked")),
-        lambda self: None,
-    )
+    class M(SplitInitMixin):  # pylint: disable=too-few-public-methods
+        """Class inheriting SplitInitMixin and calling apply_split_inits."""
 
-    z = Z(1, bar=5)
-    assert hasattr(z, "bar")
+        def __init__(self):  # pylint: disable=super-init-not-called
+            apply_split_inits_old(self)
 
+    class NoInit:  # pylint: disable=too-few-public-methods
+        """Class with no init method."""
 
-# 556: except exception (after already excepting TypeError earlier)
-def test_apply_split_inits_old_direct_call_fallback(monkeypatch):
-    """Test: super fails, then base.__init__ raises an exception."""
-    # Patch super() to raise TypeError for test coverage
-    original_super = super
+    def test_find_calling_class_success(self):
+        """Test ensuring _find_calling_class succeeds."""
+        dummy = self.DummyWithApplyOld()
+        cls = _find_calling_class_from_init_old(dummy)
+        assert cls is self.DummyWithApplyOld
 
-    class MockSuper:  # pylint: disable=too-few-public-methods
-        """A class to mock the super function."""
+    def test_find_calling_class_skips_no_init(self):
+        """Test: Class with no init"""
+        obj = self.NoInit()
+        assert _find_calling_class_from_init_old(obj) is None
 
-        def __init__(self, base, obj):
-            raise TypeError("force fallback")
+    def test_find_calling_class_handles_typeerror(self):
+        """Test: Class with non-introspectable init (simulate TypeError)"""
+        # Simulate with a built-in that raises TypeError on inspection
+        obj = self.BuiltinWrapper()
+        assert _find_calling_class_from_init_old(obj) is None
 
-    monkeypatch.setattr("builtins.super", MockSuper)
-
-    class Bar:  # pylint:disable=too-few-public-methods
-        """Class whose base.__init__ should raise an exception."""
-
-        def __init__(self, bar):  # pylint: disable=disallowed-name
-            self.bar = bar  # pylint: disable=disallowed-name
-            # This makes it raise a TypeError while doing the base.__init__:
-            raise TypeError
-
-    class FailSuper(Bar):  # pylint: disable=too-few-public-methods
-        """Class that should fail super ad fall back to base.__init__"""
-
-        def __init__(
-            self, *args, **kwargs
-        ):  # pylint: disable=super-init-not-called
-            apply_split_inits_old(self, args=args, kwargs=kwargs)
-
-    fortytwo = 42
-    f = FailSuper(bar=fortytwo)
-    assert f.bar == fortytwo
-
-    monkeypatch.setattr("builtins.super", original_super)  # Restore
+    def test_find_calling_class_positive(self):
+        """Test: Positive detection (init calls apply_split_inits)."""
+        obj = self.M()
+        assert _find_calling_class_from_init_old(obj) == self.M
 
 
-# _find_calling_class_from_init tests
+class Test_apply_split_inits_old:  # pylint:disable=invalid-name
+    """Tests for apply_split_inits_old."""
 
-
-def test_find_calling_class_success():
-    """Test ensuring _find_calling_class succeeds."""
-    dummy = DummyWithApplyOld()
-    cls = _find_calling_class_from_init_old(dummy)
-    assert cls is DummyWithApplyOld
-
-
-def test_find_calling_class_skips_no_init():
-    """Test: Class with no init"""
-    obj = NoInit()
-    assert _find_calling_class_from_init_old(obj) is None
-
-
-def test_find_calling_class_handles_typeerror():
-    """Test: Class with non-introspectable init (simulate TypeError)"""
-    # Simulate with a built-in that raises TypeError on inspection
-    obj = BuiltinWrapper()
-    assert _find_calling_class_from_init_old(obj) is None
-
-
-def test_find_calling_class_positive():
-    """Test: Positive detection (init calls apply_split_inits)."""
-    obj = M()
-    assert _find_calling_class_from_init_old(obj) == M
-
-
-# apply_split_inits tests
-
-
-def test_apply_split_inits_manual_skip():
-    """Test: Skip class manually"""
-    obj = Skip()
-    assert hasattr(obj, "_init_leftovers")
-
-
-# Direct function call tests
-
-
-def test_split_args_for_inits_applies_init_properly():
-    """Test: Mixin correctly delegates to helper"""
-    a_val = 10
-    b_val = 20
-    c_val = 30
-    three = 3
-    e = E1(a=a_val, b=b_val, c=c_val)
-    assert e._a == a_val  # pylint: disable=protected-access
-    # assert not e._b_kwargs  # pylint: disable=protected-access
-    assert e._b_kwargs == {
-        "b": b_val,
-        "c": c_val,
-    }  # pylint: disable=protected-access
-    assert not hasattr(e, "_init_leftovers")
-    assert len(e.split) == three
-    assert e.split["leftovers"]["kwargs"]["b"] == b_val
-    assert e.split["leftovers"]["kwargs"]["c"] == c_val
-
-
-# SplitInitMixin tests
-
-
-def test_splitinitmixin_applies_init_properly():
-    """Test: Mixin correctly delegates to helper"""
-    x_val = 10
-    y_val = 20
-    c = M3(x=x_val, y=y_val)
-    assert c._x == x_val  # pylint: disable=protected-access
-    assert c._y == y_val  # pylint: disable=protected-access
-    assert hasattr(c, "_init_leftovers")
-
-
-# This test fails due to the conditions listed in the mixin class docstring.
-# auto_split_init SplitInitMixin extra tests
-def test_apply_split_inits_correctly_applies_and_sets_leftovers():
-    """Test: Normal split, one base has **kwargs"""
-    c = C1(a=1, b=2, c=3)
-    # Ideally we would want this to exist, but due to the described conditions
-    # A1 is never initialized.
-    # But with the nwe version, we're ok!
-    assert c._a == 1  # pylint: disable=protected-access
-    # assert not hasattr(c, "_a")
-    # Note how it passes the params for A1 to B1:
-    # Not anymore!
-    assert c._b_kwargs == {"b": 2, "c": 3}  # pylint: disable=protected-access
-    # assert c._b_kwargs == {"a": 1}  # pylint: disable=protected-access
-    # Note how it then leaves the B1 params as leftovers:
-    assert c._init_leftovers == {  # pylint: disable=protected-access
-        "args": [],
-        "kwargs": {"b": 2, "c": 3},
-    }
-
-
-# This test fails due to the conditions listed in the decorator docstring.
-# auto_split_init Decorator extra tests
-def test_auto_split_init_decorator_behavior():
-    """Test: Confirm decorator wraps and initializes correctly"""
-    d = D1(a=1, extra="stuff")
-    # Ideally we would want this to exist, but due to the described conditions
-    # A1 is never initialized.
-    # Nut with the new version, now we're ok!
-    assert d._a == 1  # pylint: disable=protected-access
-    # assert not hasattr(d, "_a")
-    # Note how it passes the params for A1 to B1:
-    # Not anymore!
-    assert d._b_kwargs == {  # pylint: disable=protected-access
-        "extra": "stuff"
-    }
-    # assert d._b_kwargs == {"a": 1}  # pylint: disable=protected-access
-    assert hasattr(d, "_init_leftovers")
-    # Note how it then still leaves the extra params as leftovers:
-    assert d._init_leftovers == {  # pylint: disable=protected-access,no-member
-        "args": [],
-        "kwargs": {"extra": "stuff"},
-    }
-
-
-# Test positional and keyword bindings:
-
-
-def test_positional_binding():
-    """Test to ensure positional arg binding is passed correctly."""
-    a_val = 5
-    c = C2(a_val)
-    assert c._a == a_val  # pylint: disable=protected-access
-
-
-def test_keyword_binding():
-    """Test to ensure keyword binding is passed correctly."""
-    a_val = 10
-    c = C2(a=a_val)
-    assert c._a == a_val  # pylint: disable=protected-access
-
-
-# Test caveats
-
-
-def test_caveat_manual_ordering():
-    """Tests that the ordering of the parent classes is preserved."""
-
-    class First:  # pylint: disable=too-few-public-methods
-        """Class creating the member "order"."""
-
-        def __init__(self):
-            self.order = ["first"]
-
-    class Second:  # pylint: disable=too-few-public-methods
-        """Class that must be initialized after First,
-        though it doesn't directly call First."""
-
-        def __init__(self):
-            self.order.append("second")  # pylint: disable=no-member
-
-    class Manual(First, Second):  # pylint: disable=too-few-public-methods
-        """Class to combine First and Second."""
-
-        def __init__(self):
-            self.order = []
-            split = split_args_for_inits_strict_kwargs(type(self), (), {})
-            First.__init__(self)
-            Second.__init__(self)
-            self.leftovers = split["leftovers"]
-
-    m = Manual()
-    assert m.order == ["first", "second"]
-
-
-def test_split_leftovers_preserved():
-    """Test that leftovers are preserved."""
-    a = 1
-    b = 2
-    extra = "hello"
-    ninetynine = 99
-    obj = C3(a, b=b, extra=extra, unknown_kwarg=ninetynine)
-    assert obj._a == a  # pylint: disable=protected-access
-    assert obj.b == b
-    # This isn't what happens either,
-    # since the B parent accepts **kwargs but doen't call a parent,
-    # so **kwargs aren't actually passed to it.
-    # Now it does, so this is fine.
-    assert obj.extra == extra
-    # assert not obj.extra
-    assert obj.leftovers["kwargs"] == {
-        "extra": extra,
-        "unknown_kwarg": ninetynine,
-    }
-
-
-def test_var_kwarg_binding_within_accepted_keys():
-    """Test that when a positional arg and kwarg (by name) are both given,
-    positional arg takes precedence and kwarg goes into leftovers."""
-
-    class AcceptsKwargs:  # pylint: disable=too-few-public-methods
-        """Class that accepts kwargs."""
+    class AcceptsAll:  # pylint: disable=too-few-public-methods
+        """Class that accepts all kwargs."""
 
         def __init__(self, **kwargs):
-            self.caught = kwargs.get("target", None)
+            pass
 
-    class AcceptsDirect:  # pylint: disable=too-few-public-methods
-        """Class that accepts a positional arg."""
-
-        def __init__(self, target):
-            self.target = target
-
-    class Combiner(
-        AcceptsDirect, AcceptsKwargs
+    class AcceptsAllDummy(
+        AcceptsAll
     ):  # pylint: disable=too-few-public-methods
-        """Class to combine AcceptsDirect and AcceptsKwargs."""
+        """Wrapper class for AcceptsAll class."""
+
+    class BuiltinTypeClass:  # pylint: disable=too-few-public-methods
+        """Class that should raise TypeError in dis.get_instructions."""
+
+        __init__ = object.__init__
+
+    class Skip(SplitInitMixin):  # pylint: disable=too-few-public-methods
+        """Class with a defined skip class."""
+
+        def __init__(self):  # pylint: disable=super-init-not-called
+            apply_split_inits_old(self, skip_class=type(self))
+
+    def test_apply_split_inits_manual_skip(self):
+        """Test: Skip class manually"""
+        obj = self.Skip()
+        assert hasattr(obj, "_init_leftovers")
+
+    # Line tests: raise TypeError handling
+    def test_split_args_with_var_kwargs(self):
+        """Test: Class with **kwargs"""
+        result = split_args_for_inits_strict_kwargs(
+            self.AcceptsAllDummy, [], {"z": 1}
+        )
+        assert result[self.AcceptsAll]["kwargs"] == {"z": 1}
+        assert result[LEFTOVERS]["kwargs"] == {"z": 1}
+
+    def test_find_calling_class_typeerror_branch(self):
+        """Test that should raise TypeError and hit that branch."""
+        instance = self.BuiltinTypeClass()
+        result = _find_calling_class_from_init_old(instance)
+        assert result is None
+
+    # Line test: if skip_class is None: (which means _find_calling_class_from_init failed)
+    def test_apply_split_inits_old_skip_class_none_branch(self, monkeypatch):
+        """Test forcing the _find_calling_class_from_init to fail."""
+
+        class X:  # pylint: disable=too-few-public-methods
+            """Class with one positional arg."""
+
+            def __init__(self, foo):  # pylint: disable=disallowed-name
+                self.foo = foo  # pylint: disable=disallowed-name
+
+        class Y:  # pylint: disable=too-few-public-methods
+            """Class with one kwarg."""
+
+            def __init__(self, bar=2):  # pylint: disable=disallowed-name
+                self.bar = bar  # pylint: disable=disallowed-name
+
+        class Z(X, Y):  # pylint: disable=too-few-public-methods
+            """Class to inherit two other classes."""
+
+            def __init__(
+                self, *args, **kwargs
+            ):  # pylint: disable=super-init-not-called
+                apply_split_inits_old(self, args=args, kwargs=kwargs)
+
+        # Force _find_calling_class_from_init to raise TypeError
+        monkeypatch.setattr(
+            "python_template.utils.split_args_for_inits._find_calling_class_from_init",
+            # lambda self: (_ for _ in ()).throw(TypeError("mocked")),
+            lambda self: None,
+        )
+
+        z = Z(1, bar=5)
+        assert hasattr(z, "bar")
+
+    # Line test: Except exception (after already excepting TypeError earlier)
+    def test_apply_split_inits_old_direct_call_fallback(self, monkeypatch):
+        """Test: super fails, then base.__init__ raises an exception."""
+        # Patch super() to raise TypeError for test coverage
+        original_super = super
+
+        class MockSuper:  # pylint: disable=too-few-public-methods
+            """A class to mock the super function."""
+
+            def __init__(self, base, obj):
+                raise TypeError("force fallback")
+
+        monkeypatch.setattr("builtins.super", MockSuper)
+
+        class Bar:  # pylint:disable=too-few-public-methods
+            """Class whose base.__init__ should raise an exception."""
+
+            def __init__(self, bar):  # pylint: disable=disallowed-name
+                self.bar = bar  # pylint: disable=disallowed-name
+                # This makes it raise a TypeError while doing the base.__init__:
+                raise TypeError
+
+        class FailSuper(Bar):  # pylint: disable=too-few-public-methods
+            """Class that should fail super ad fall back to base.__init__"""
+
+            def __init__(
+                self, *args, **kwargs
+            ):  # pylint: disable=super-init-not-called
+                apply_split_inits_old(self, args=args, kwargs=kwargs)
+
+        fortytwo = 42
+        f = FailSuper(bar=fortytwo)
+        assert f.bar == fortytwo
+
+        monkeypatch.setattr("builtins.super", original_super)  # Restore
+
+
+class Test__find_calling_class_from_init:  # pylint:disable=invalid-name,too-few-public-methods
+    """Tests for _find_calling_class_from_init."""
+
+    class Empty:  # pylint: disable=too-few-public-methods
+        """Empty class."""
+
+    class EmptyDummy(Empty):  # pylint: disable=too-few-public-methods
+        """Wrapper class for Empty class."""
+
+    # Line test: positive branches of if not (init := base.__dict__.get("__init__")):
+    def test_split_args_with_no_init(self):
+        """Test: Class with no __init__"""
+        result = split_args_for_inits_strict_kwargs(
+            self.EmptyDummy, [1], {"x": 2}
+        )
+        assert result[LEFTOVERS]["args"] == [1]
+        assert result[LEFTOVERS]["kwargs"] == {"x": 2}
+
+
+class Test_split_args_for_inits:  # pylint:disable=invalid-name
+    """Tests for split_args_for_inits"""
+
+    class A1:  # pylint: disable=too-few-public-methods
+        """Class accepting one positional arg."""
+
+        def __init__(self, a):
+            self._a = a
+            super().__init__()
+
+    class AKeywords:  # pylint: disable=too-few-public-methods
+        """A class with optional positional args and one kwarg."""
+
+        def __init__(self, *, a_kwarg):
+            self.a_kwarg = a_kwarg
+
+    class B1:  # pylint: disable=too-few-public-methods
+        """Class accepting variable kwargs."""
+
+        def __init__(self, **kwargs):
+            self._b_kwargs = kwargs
+            super().__init__()
+
+    class B2:  # pylint: disable=too-few-public-methods
+        """Class with one kwarg that accepts all kwargs."""
+
+        def __init__(self, b=0, **kwargs):
+            self.b = b
+            self.extra = kwargs.get("extra", None)
+
+    class BStarKwargs:  # pylint: disable=too-few-public-methods
+        """Class with star kwargs."""
+
+        def __init__(self, **kwargs):
+            # self.b_seen = "bk" in kwargs
+            self.b_seen = True
+            self.bk = kwargs.get("bk", None)
+
+    class C3(A1, B2):  # pylint: disable=too-few-public-methods
+        """Class calling other classes."""
+
+        def __init__(
+            self, *args, **kwargs
+        ):  # pylint: disable=super-init-not-called
+            self.split = split_args_for_inits_strict_kwargs(
+                type(self), args, kwargs
+            )
+            # A1.__init__(self, *self.split[A1]["args"], **self.split[A1]["kwargs"])
+            # B2.__init__(self, *self.split[B2]["args"], **self.split[B2]["kwargs"])
+            apply_split_inits(self, type(self), args, kwargs)
+            self.leftovers = self.split[LEFTOVERS]
+
+    class CombinedClass(
+        AKeywords, BStarKwargs
+    ):  # pylint: disable=too-few-public-methods
+        """Class combining AKeywords and BStarKwargs."""
 
         def __init__(self, *args, **kwargs):
             self.split = split_args_for_inits_strict_kwargs(
                 type(self), args, kwargs
             )
-            AcceptsDirect.__init__(
+            Test_split_args_for_inits.AKeywords.__init__(
                 self,
-                *self.split[AcceptsDirect]["args"],
-                **self.split[AcceptsDirect]["kwargs"],
+                *self.split[Test_split_args_for_inits.AKeywords]["args"],
+                **self.split[Test_split_args_for_inits.AKeywords]["kwargs"],
             )
-            AcceptsKwargs.__init__(
+            Test_split_args_for_inits.BStarKwargs.__init__(
                 self,
-                *self.split[AcceptsKwargs]["args"],
-                **self.split[AcceptsKwargs]["kwargs"],
+                *self.split[Test_split_args_for_inits.BStarKwargs]["args"],
+                **self.split[Test_split_args_for_inits.BStarKwargs]["kwargs"],
             )
-            self.leftovers = self.split["leftovers"]
+            self.leftovers = self.split[LEFTOVERS]
 
-    val = "value"
-    check = "check"
-    unused = "meh"
-    c = Combiner(val, target=check, unused=unused)
-    assert c.target == val
-    # This test is wrong. AcceptsKwargs will get nothing,
-    # and AcceptsDirect will get both "check" and "value" for target
-    # (and then put back "check").
-    # But with the new version, this works as expected.
-    assert c.caught == check
-    # assert not c.caught
-    assert c.leftovers["kwargs"] == {"target": check, "unused": unused}
+    class E1(A1, B1):  # pylint: disable=too-few-public-methods
+        """Test class E1. For use of the function."""
+
+        def __init__(
+            self, *args, **kwargs
+        ):  # pylint: disable=super-init-not-called
+            self.split = split_args_for_inits_strict_kwargs(
+                type(self), args, kwargs
+            )
+            # A1.__init__(self, *self.split[A1]["args"], **self.split[A1]["kwargs"])
+            # B1.__init__(self, *self.split[B1]["args"], **self.split[B1]["kwargs"])
+            apply_split_inits(self, type(self), args, kwargs)
+            print(f"E leftovers: {self.split['leftovers']}")
+
+    class F:  # pylint: disable=too-few-public-methods
+        """Class with one keyword arg"""
+
+        def __init__(self, a=1):
+            pass
+
+    class FDummy(F):  # pylint: disable=too-few-public-methods
+        """Wrapper class for F class."""
+
+    class P1:  # pylint: disable=too-few-public-methods
+        """Class with one positional arg and one kwarg."""
+
+        def __init__(self, a, b=2):
+            pass
+
+    class P1Dummy(P1):  # pylint: disable=too-few-public-methods
+        """Dummy wrapper class for P1"""
+
+    class P2:  # pylint: disable=too-few-public-methods
+        """Class with two kwargs."""
+
+        def __init__(
+            self, foo=None, bar=None
+        ):  # pylint: disable=disallowed-name
+            pass
+
+    class P2Dummy(P2):  # pylint: disable=too-few-public-methods
+        """Dummy wrapper class for P2."""
+
+    class Q(P2):  # pylint: disable=too-few-public-methods
+        """Class inheriting P2 that has its own stuff too."""
+
+        def __init__(self, q1, **kwargs):
+            self.q1 = q1
+            super().__init__(**kwargs)
+
+    class QDummy(Q):  # pylint:disable=too-few-public-methods
+        """Wrapper class or Q."""
+
+    def test_split_args_for_inits_applies_init_properly(self):
+        """Test: Mixin correctly delegates to helper"""
+        a_val = 10
+        b_val = 20
+        c_val = 30
+        three = 3
+        e = self.E1(a=a_val, b=b_val, c=c_val)
+        assert e._a == a_val  # pylint: disable=protected-access
+        # assert not e._b_kwargs  # pylint: disable=protected-access
+        assert e._b_kwargs == {
+            "b": b_val,
+            "c": c_val,
+        }  # pylint: disable=protected-access
+        # assert not hasattr(e, "_init_leftovers")
+        assert (
+            e._init_leftovers["kwargs"]  # pylint: disable=no-member
+            == e._b_kwargs
+        )  # pylint: disable=protected-access
+        assert len(e.split) == three
+        assert e.split[LEFTOVERS]["kwargs"]["b"] == b_val
+        assert e.split[LEFTOVERS]["kwargs"]["c"] == c_val
+
+    # Line test: positive branch of if remaining_args:
+    def test_split_args_with_positional_args(self):
+        """Test: Positional argument matching (covers if remaining_args: branch)"""
+
+        args = [1]
+        kwargs = {"b": 5, "x": 42}
+        result = split_args_for_inits_strict_kwargs(self.P1Dummy, args, kwargs)
+        assert result[self.P1]["args"] == [1]
+        assert result[self.P1]["kwargs"] == {"b": 5}
+        assert result[LEFTOVERS]["kwargs"] == {"x": 42}
+
+    # Line test: positive branch of if key in keyword_params:
+    def test_split_args_with_kwarg_param(self):
+        """Test: positive branch of if key in keyword_params"""
+        a_val = 10
+        args = ()
+        kwargs = {"a": a_val}
+        result = split_args_for_inits_strict_kwargs(self.FDummy, args, kwargs)
+        assert result[self.F]["kwargs"] == kwargs
+
+    def test_bind_kwargs_from_remaining(self):
+        """Test that binds kwargs from remaining (for the positive branch above)"""
+        a_kwarg = 42
+        bk = "present"
+        unused = "leftover"
+        obj = self.CombinedClass(a_kwarg=a_kwarg, bk=bk, unused=unused)
+        assert obj.a_kwarg == a_kwarg
+        # Beacuse of the way it is set up looking for bk in kwargs, it won't get bk.
+        # assert obj.bk == bk
+        assert obj.b_seen
+        assert obj.leftovers["kwargs"] == {"bk": bk, "unused": unused}
+
+    # Line test: positive branch of if not (init := base.__dict__.get("__init__", None)):
+    # This I think is covered by the test below?
+    # Line test: positive branch of if key in accepted_keys:
+    def test_split_args_with_filtered_kwargs(self):
+        """Test: Accepted key filtering (covers if key in accepted_keys:)"""
+        args = []
+        kwargs = {"foo": "FOO", "baz": "BAZ"}
+        result = split_args_for_inits_strict_kwargs(self.P2Dummy, args, kwargs)
+        assert result[self.P2]["kwargs"] == {"foo": "FOO"}
+        assert result[LEFTOVERS]["kwargs"] == {"baz": "BAZ"}
+
+        kwargs["q1"] = "q1"
+        result = split_args_for_inits_strict_kwargs(self.QDummy, args, kwargs)
+        assert result[self.Q]["kwargs"] == {
+            "q1": kwargs["q1"],
+            "foo": kwargs["foo"],
+        }
+        assert result[self.P2] == {
+            "args": [],
+            "kwargs": {},
+            "args_assigned_positionally": [],
+        }
+        assert result[LEFTOVERS] == {
+            "args": [],
+            "kwargs": {"baz": kwargs["baz"]},
+        }
+
+    def test_split_leftovers_preserved(self):
+        """Test that leftovers are preserved."""
+        a = 1
+        b = 2
+        extra = "hello"
+        ninetynine = 99
+        obj = self.C3(a, b=b, extra=extra, unknown_kwarg=ninetynine)
+        assert obj._a == a  # pylint: disable=protected-access
+        assert obj.b == b
+        # This isn't what happens either,
+        # since the B parent accepts **kwargs but doen't call a parent,
+        # so **kwargs aren't actually passed to it.
+        # Now it does, so this is fine.
+        assert obj.extra == extra
+        # assert not obj.extra
+        assert obj.leftovers["kwargs"] == {
+            "extra": extra,
+            "unknown_kwarg": ninetynine,
+        }
+
+    def test_caveat_manual_ordering(self):
+        """Tests that the ordering of the parent classes is preserved."""
+
+        class First:  # pylint: disable=too-few-public-methods
+            """Class creating the member "order"."""
+
+            def __init__(self):
+                self.order = ["first"]
+
+        class Second:  # pylint: disable=too-few-public-methods
+            """Class that must be initialized after First,
+            though it doesn't directly call First."""
+
+            def __init__(self):
+                self.order.append("second")  # pylint: disable=no-member
+
+        class Manual(First, Second):  # pylint: disable=too-few-public-methods
+            """Class to combine First and Second."""
+
+            def __init__(self):  # pylint: disable=super-init-not-called
+                self.order = []
+                split = split_args_for_inits_strict_kwargs(type(self), (), {})
+                # First.__init__(self)
+                # Second.__init__(self)
+                apply_split_inits(self, type(self), (), {})
+                self.leftovers = split[LEFTOVERS]
+
+        m = Manual()
+        assert m.order == ["first", "second"]
+
+    def test_var_kwarg_binding_within_accepted_keys(self):
+        """Test that when a positional arg and kwarg (by name) are both given,
+        positional arg takes precedence and kwarg goes into leftovers."""
+
+        class AcceptsKwargs:  # pylint: disable=too-few-public-methods
+            """Class that accepts kwargs."""
+
+            def __init__(self, **kwargs):
+                self.caught = kwargs.get("target", None)
+
+        class AcceptsDirect:  # pylint: disable=too-few-public-methods
+            """Class that accepts a positional arg."""
+
+            def __init__(self, target):
+                self.target = target
+
+        class Combiner(
+            AcceptsDirect, AcceptsKwargs
+        ):  # pylint: disable=too-few-public-methods
+            """Class to combine AcceptsDirect and AcceptsKwargs."""
+
+            def __init__(
+                self, *args, **kwargs
+            ):  # pylint: disable=super-init-not-called
+                self.split = split_args_for_inits_strict_kwargs(
+                    type(self), args, kwargs
+                )
+                # AcceptsDirect.__init__(
+                #     self,
+                #     *self.split[AcceptsDirect]["args"],
+                #     **self.split[AcceptsDirect]["kwargs"],
+                # )
+                # AcceptsKwargs.__init__(
+                #     self,
+                #     *self.split[AcceptsKwargs]["args"],
+                #     **self.split[AcceptsKwargs]["kwargs"],
+                # )
+                apply_split_inits(self, type(self), args, kwargs)
+                self.leftovers = self.split[LEFTOVERS]
+
+        val = "value"
+        check = "check"
+        unused = "meh"
+        c = Combiner(val, target=check, unused=unused)
+        assert c.target == val
+        # This test is wrong. AcceptsKwargs will get nothing,
+        # and AcceptsDirect will get both "check" and "value" for target
+        # (and then put back "check").
+        # But with the new version, this works as expected.
+        assert c.caught == check
+        # assert not c.caught
+        assert c.leftovers["kwargs"] == {"target": check, "unused": unused}
+
+
+class Test_SplitInitMixin:  # pylint:disable=invalid-name
+    """Tests for the SplitInitMixin class"""
+
+    class A1:  # pylint: disable=too-few-public-methods
+        """Class accepting one positional arg."""
+
+        def __init__(self, a):
+            self._a = a
+            super().__init__()
+
+    class B1:  # pylint: disable=too-few-public-methods
+        """Class accepting variable kwargs."""
+
+        def __init__(self, **kwargs):
+            self._b_kwargs = kwargs
+            super().__init__()
+
+    class C1(SplitInitMixin, A1, B1):  # pylint: disable=too-few-public-methods
+        """Class using mixin with a parent with a positional arg and a parent with a
+        kwarg"""
+
+        def __init__(
+            self, *args, **kwargs
+        ):  # pylint: disable=useless-parent-delegation
+            # apply_split_inits(self, args, kwargs)
+            super().__init__(*args, **kwargs)
+            # SplitInitMixin.__init__(self, *args, **kwargs)
+
+    class C2(SplitInitMixin, A1):  # pylint: disable=too-few-public-methods
+        """Class using mixin with one other parent with positional arg."""
+
+        def __init__(
+            self, *args, **kwargs
+        ):  # pylint: disable=useless-parent-delegation
+            super().__init__(*args, **kwargs)
+            # pass
+
+    class M1:  # pylint: disable=too-few-public-methods
+        """Class with one positional arg."""
+
+        def __init__(self, x):
+            self._x = x
+
+    class M2:  # pylint: disable=too-few-public-methods
+        """Class with one positional arg."""
+
+        def __init__(self, y):
+            self._y = y
+
+    class M3(SplitInitMixin, M1, M2):  # pylint: disable=too-few-public-methods
+        """Class with parent classes inheriting SplitInitMixin."""
+
+        def __init__(
+            self, *args, **kwargs
+        ):  # pylint: disable=useless-parent-delegation
+            super().__init__(*args, **kwargs)
+            # apply_split_inits(self, type(self), args, kwargs)
+
+    def test_splitinitmixin_applies_init_properly(self):
+        """Test: Mixin correctly delegates to helper"""
+        x_val = 10
+        y_val = 20
+        c = self.M3(x=x_val, y=y_val)
+        assert c._x == x_val  # pylint: disable=protected-access
+        assert c._y == y_val  # pylint: disable=protected-access
+        assert hasattr(c, "_init_leftovers")
+
+    # This test fails due to the conditions listed in the mixin class docstring.
+    # auto_split_init SplitInitMixin extra tests
+    def test_apply_split_inits_correctly_applies_and_sets_leftovers(self):
+        """Test: Normal split, one base has **kwargs"""
+        c = self.C1(a=1, b=2, c=3)
+        # Ideally we would want this to exist, but due to the described conditions
+        # A1 is never initialized.
+        # But with the new version, we're ok!
+        assert c._a == 1  # pylint: disable=protected-access
+        # assert not hasattr(c, "_a")
+        # Note how it passes the params for A1 to B1:
+        # Not anymore!
+        assert c._b_kwargs == {  # pylint: disable=protected-access
+            "b": 2,
+            "c": 3,
+        }
+        # assert c._b_kwargs == {"a": 1}  # pylint: disable=protected-access
+        # Note how it then leaves the B1 params as leftovers:
+        assert c._init_leftovers == {  # pylint: disable=protected-access
+            "args": [],
+            "kwargs": {"b": 2, "c": 3},
+        }
+
+    # Test positional and keyword bindings:
+
+    def test_positional_binding(self):
+        """Test to ensure positional arg binding is passed correctly."""
+        a_val = 5
+        c = self.C2(a_val)
+        assert c._a == a_val  # pylint: disable=protected-access
+
+    def test_keyword_binding(self):
+        """Test to ensure keyword binding is passed correctly."""
+        a_val = 10
+        c = self.C2(a=a_val)
+        assert c._a == a_val  # pylint: disable=protected-access
+
+
+class Test_decorator:  # pylint:disable=invalid-name,too-few-public-methods
+    """Tests for the decorator."""
+
+    class A1:  # pylint: disable=too-few-public-methods
+        """Class accepting one positional arg."""
+
+        def __init__(self, a):
+            self._a = a
+            super().__init__()
+
+    class B1:  # pylint: disable=too-few-public-methods
+        """Class accepting variable kwargs."""
+
+        def __init__(self, **kwargs):
+            self._b_kwargs = kwargs
+            super().__init__()
+
+    @auto_split_init
+    class D1(A1, B1):  # pylint: disable=too-few-public-methods
+        """Class using decorator."""
+
+        def __init__(
+            self, *args, **kwargs
+        ):  # pylint: disable=super-init-not-called
+            pass
+
+    # This test fails due to the conditions listed in the decorator docstring.
+    # auto_split_init Decorator extra tests
+    def test_auto_split_init_decorator_behavior(self):
+        """Test: Confirm decorator wraps and initializes correctly"""
+        d = self.D1(a=1, extra="stuff")
+        # Ideally we would want this to exist, but due to the described conditions
+        # A1 is never initialized.
+        # Nut with the new version, now we're ok!
+        assert d._a == 1  # pylint: disable=protected-access
+        # assert not hasattr(d, "_a")
+        # Note how it passes the params for A1 to B1:
+        # Not anymore!
+        assert d._b_kwargs == {  # pylint: disable=protected-access
+            "extra": "stuff"
+        }
+        # assert d._b_kwargs == {"a": 1}  # pylint: disable=protected-access
+        assert hasattr(d, "_init_leftovers")
+        # Note how it then still leaves the extra params as leftovers:
+        assert (  # pylint: disable=protected-access,no-member
+            d._init_leftovers
+            == {
+                "args": [],
+                "kwargs": {"extra": "stuff"},
+            }
+        )
 
 
 # if __name__ == "__main__":

--- a/tests/test_utils/test_split_args_for_inits.py
+++ b/tests/test_utils/test_split_args_for_inits.py
@@ -1,11 +1,30 @@
 """This file contains tests for the functions, classes, and decorators
 in the split_args_for_inits module."""
 
+import builtins
+
 from python_template.utils import (
     SplitInitMixin,
     auto_split_init,
     split_args_for_inits_strict_kwargs,
 )
+from python_template.utils.split_args_for_inits import (
+    _find_calling_class_from_init,
+    apply_split_inits,
+)
+
+# Classes for tests:
+
+
+class AcceptsAll:  # pylint: disable=too-few-public-methods
+    """Class that accepts all kwargs."""
+
+    def __init__(self, **kwargs):
+        pass
+
+
+class AcceptsAllDummy(AcceptsAll):  # pylint: disable=too-few-public-methods
+    """Wrapper class for AcceptsAll class."""
 
 
 class A:  # pylint: disable=too-few-public-methods
@@ -17,6 +36,14 @@ class A:  # pylint: disable=too-few-public-methods
         self.a2 = a2
 
 
+class A1:  # pylint: disable=too-few-public-methods
+    """Class accepting one positional arg."""
+
+    def __init__(self, a):
+        self._a = a
+        super().__init__()
+
+
 class B:  # pylint: disable=too-few-public-methods
     """Test class B."""
 
@@ -24,6 +51,18 @@ class B:  # pylint: disable=too-few-public-methods
         print(f"B init: b1={b1}, b2={b2}")
         self.b1 = b1
         self.b2 = b2
+
+
+class B1:  # pylint: disable=too-few-public-methods
+    """Class accepting variable kwargs."""
+
+    def __init__(self, **kwargs):
+        self._b_kwargs = kwargs
+        super().__init__()
+
+
+class BuiltinWrapper(builtins.int):  # pylint: disable=too-few-public-methods
+    """Wrapper for a builtin class."""
 
 
 class C(SplitInitMixin, A, B):  # pylint: disable=too-few-public-methods
@@ -34,6 +73,27 @@ class C(SplitInitMixin, A, B):  # pylint: disable=too-few-public-methods
         print(
             f"C leftovers: {self._init_leftovers}"  # pylint: disable=no-member
         )
+
+
+class C1(SplitInitMixin, A1, B1):  # pylint: disable=too-few-public-methods
+    """Class using mixin with a parent with a positional arg and a parent with a
+    kwarg"""
+
+    def __init__(
+        self, *args, **kwargs
+    ):  # pylint: disable=useless-parent-delegation
+        # apply_split_inits(self, args, kwargs)
+        super().__init__(*args, **kwargs)
+        # SplitInitMixin.__init__(self, *args, **kwargs)
+
+
+class C2(SplitInitMixin, A1):  # pylint: disable=too-few-public-methods
+    """Class using mixin with one other parent with positional arg."""
+
+    def __init__(
+        self, *args, **kwargs
+    ):  # pylint: disable=useless-parent-delegation
+        super().__init__(*args, **kwargs)
 
 
 @auto_split_init
@@ -48,6 +108,16 @@ class D(A, B):  # pylint: disable=too-few-public-methods
         )
 
 
+@auto_split_init
+class D1(A1, B1):  # pylint: disable=too-few-public-methods
+    """Class using decorator."""
+
+    def __init__(
+        self, *args, **kwargs
+    ):  # pylint: disable=super-init-not-called
+        pass
+
+
 class E(A, B):  # pylint: disable=too-few-public-methods
     """Test class E. For use of the function."""
 
@@ -58,6 +128,88 @@ class E(A, B):  # pylint: disable=too-few-public-methods
         A.__init__(self, *self.split[A]["args"], **self.split[A]["kwargs"])
         B.__init__(self, *self.split[B]["args"], **self.split[B]["kwargs"])
         print(f"E leftovers: {self.split['leftovers']}")
+
+
+class E1(A1, B1):  # pylint: disable=too-few-public-methods
+    """Test class E1. For use of the function."""
+
+    def __init__(self, *args, **kwargs):
+        self.split = split_args_for_inits_strict_kwargs(
+            type(self), args, kwargs
+        )
+        A1.__init__(self, *self.split[A1]["args"], **self.split[A1]["kwargs"])
+        B1.__init__(self, *self.split[B1]["args"], **self.split[B1]["kwargs"])
+        print(f"E leftovers: {self.split['leftovers']}")
+
+
+class Empty:  # pylint: disable=too-few-public-methods
+    """Empty class."""
+
+
+class M(SplitInitMixin):  # pylint: disable=too-few-public-methods
+    """Class inheriting SplitInitMixin and calling apply_split_inits."""
+
+    def __init__(self):  # pylint: disable=super-init-not-called
+        apply_split_inits(self)
+
+
+class M1:  # pylint: disable=too-few-public-methods
+    """Class with one positional arg."""
+
+    def __init__(self, x):
+        self._x = x
+
+
+class M2:  # pylint: disable=too-few-public-methods
+    """Class with one positional arg."""
+
+    def __init__(self, y):
+        self._y = y
+
+
+class M3(SplitInitMixin, M1, M2):  # pylint: disable=too-few-public-methods
+    """Class with parent classes inheriting SplitInitMixin."""
+
+    def __init__(
+        self, *args, **kwargs
+    ):  # pylint: disable=useless-parent-delegation
+        super().__init__(*args, **kwargs)
+
+
+class NoInit:  # pylint: disable=too-few-public-methods
+    """Class with no init method."""
+
+
+class P1:  # pylint: disable=too-few-public-methods
+    """Class with one positional arg and one kwarg."""
+
+    def __init__(self, a, b=2):
+        pass
+
+
+class P1Dummy(P1):  # pylint: disable=too-few-public-methods
+    """Dummy wrapper class for P1"""
+
+
+class P2:  # pylint: disable=too-few-public-methods
+    """Class with two kwargs."""
+
+    def __init__(self, foo=None, bar=None):  # pylint: disable=disallowed-name
+        pass
+
+
+class P2Dummy(P2):  # pylint: disable=too-few-public-methods
+    """Dummy wrapper class for P2."""
+
+
+class Skip(SplitInitMixin):  # pylint: disable=too-few-public-methods
+    """Class with a defined skip class."""
+
+    def __init__(self):  # pylint: disable=super-init-not-called
+        apply_split_inits(self, skip_class=Skip)
+
+
+# Full tests
 
 
 def test_split_args_for_inits_strict_kwargs():
@@ -115,6 +267,167 @@ def test_auto_split_init():
     assert d.b1 == b1
     assert d.b2 == zero
     # assert d.split["leftovers"]["kwargs"]["extra"] == extra
+
+
+# Line tests
+
+
+#  64: positive branch of if remaining_args:
+def test_split_args_with_positional_args():
+    """Test: Positional argument matching (covers if remaining_args: branch)"""
+
+    args = [1]
+    kwargs = {"b": 5, "x": 42}
+    result = split_args_for_inits_strict_kwargs(P1Dummy, args, kwargs)
+    assert result[P1]["args"] == [1]
+    assert result[P1]["kwargs"] == {"b": 5}
+    assert result["leftovers"]["kwargs"] == {"x": 42}
+
+
+#  86: positive branch of if key in accepted_keys:
+def test_split_args_with_filtered_kwargs():
+    """Test: Accepted key filtering (covers if key in accepted_keys:)"""
+    args = []
+    kwargs = {"foo": "FOO", "baz": "BAZ"}
+    result = split_args_for_inits_strict_kwargs(P2Dummy, args, kwargs)
+    assert result[P2]["kwargs"] == {"foo": "FOO"}
+    assert result["leftovers"]["kwargs"] == {"baz": "BAZ"}
+
+
+# 115: positiv branches of if not (init := base.__dict__.get("__init__")):
+def test_split_args_with_no_init():
+    """Test: Class with no __init__"""
+    result = split_args_for_inits_strict_kwargs(Empty, [1], {"x": 2})
+    assert result["leftovers"]["args"] == [1]
+    assert result["leftovers"]["kwargs"] == {"x": 2}
+
+
+# 130: raise TypeError handling
+def test_split_args_with_var_kwargs():
+    """Test: Class with **kwargs"""
+    result = split_args_for_inits_strict_kwargs(AcceptsAllDummy, [], {"z": 1})
+    assert result[AcceptsAll]["kwargs"] == {}
+    assert result["leftovers"]["kwargs"] == {"z": 1}
+
+
+# _find_calling_class_from_init tests
+
+
+def test_find_calling_class_skips_no_init():
+    """Test: Class with no init"""
+    obj = NoInit()
+    assert _find_calling_class_from_init(obj) is None
+
+
+def test_find_calling_class_handles_typeerror():
+    """Test: Class with non-introspectable init (simulate TypeError)"""
+    # Simulate with a built-in that raises TypeError on inspection
+    obj = BuiltinWrapper()
+    assert _find_calling_class_from_init(obj) is None
+
+
+def test_find_calling_class_positive():
+    """Test: Positive detection (init calls apply_split_inits)."""
+    obj = M()
+    assert _find_calling_class_from_init(obj) == M
+
+
+# apply_split_inits tests
+
+
+def test_apply_split_inits_manual_skip():
+    """Test: Skip class manually"""
+    obj = Skip()
+    assert hasattr(obj, "_init_leftovers")
+
+
+# Direct function call tests
+
+
+def test_split_args_for_inits_applies_init_properly():
+    """Test: Mixin correctly delegates to helper"""
+    a_val = 10
+    b_val = 20
+    c_val = 30
+    three = 3
+    e = E1(a=a_val, b=b_val, c=c_val)
+    assert e._a == a_val  # pylint: disable=protected-access
+    assert not e._b_kwargs  # pylint: disable=protected-access
+    assert not hasattr(e, "_init_leftovers")
+    assert len(e.split) == three
+    assert e.split["leftovers"]["kwargs"]["b"] == b_val
+    assert e.split["leftovers"]["kwargs"]["c"] == c_val
+
+
+# SplitInitMixin tests
+
+
+def test_splitinitmixin_applies_init_properly():
+    """Test: Mixin correctly delegates to helper"""
+    x_val = 10
+    y_val = 20
+    c = M3(x=x_val, y=y_val)
+    assert c._x == x_val  # pylint: disable=protected-access
+    assert c._y == y_val  # pylint: disable=protected-access
+    assert hasattr(c, "_init_leftovers")
+
+
+# This test fails due to the conditions listed in the mixin class docstring.
+# auto_split_init SplitInitMixin extra tests
+def test_apply_split_inits_correctly_applies_and_sets_leftovers():
+    """Test: Normal split, one base has **kwargs"""
+    c = C1(a=1, b=2, c=3)
+    # Ideally we would want this to exist, but due to the described conditions
+    # A1 is never initialized.
+    # assert c._a == 1
+    assert not hasattr(c, "_a")
+    # Note how it passes the params for A1 to B1:
+    # assert c._b_kwargs == {"b": 2, "c": 3}  # pylint: disable=protected-access
+    assert c._b_kwargs == {"a": 1}  # pylint: disable=protected-access
+    # Note how it then leaves the B1 params as leftovers:
+    assert c._init_leftovers == {  # pylint: disable=protected-access
+        "args": [],
+        "kwargs": {"b": 2, "c": 3},
+    }
+
+
+# This test fails due to the conditions listed in the decorator docstring.
+# auto_split_init Decorator extra tests
+def test_auto_split_init_decorator_behavior():
+    """Test: Confirm decorator wraps and initializes correctly"""
+    d = D1(a=1, extra="stuff")
+    # Ideally we would want this to exist, but due to the described conditions
+    # A1 is never initialized.
+    # assert d._a == 1
+    assert not hasattr(d, "_a")
+    # Note how it passes the params for A1 to B1:
+    # assert d._b_kwargs == {  # pylint: disable=protected-access
+    #     "extra": "stuff"
+    # }
+    assert d._b_kwargs == {"a": 1}  # pylint: disable=protected-access
+    assert hasattr(d, "_init_leftovers")
+    # Note how it then still leaves the extra params as leftovers:
+    assert d._init_leftovers == {  # pylint: disable=protected-access,no-member
+        "args": [],
+        "kwargs": {"extra": "stuff"},
+    }
+
+
+# Test positional and keyword bindings:
+
+
+def test_positional_binding():
+    """Test to ensure positional arg binding is passed correctly."""
+    a_val = 5
+    c = C2(a_val)
+    assert c._a == a_val  # pylint: disable=protected-access
+
+
+def test_keyword_binding():
+    """Test to ensure keyword binding is passed correctly."""
+    a_val = 10
+    c = C2(a=a_val)
+    assert c._a == a_val  # pylint: disable=protected-access
 
 
 # if __name__ == "__main__":

--- a/tests/test_utils/test_split_args_for_inits.py
+++ b/tests/test_utils/test_split_args_for_inits.py
@@ -1,0 +1,123 @@
+"""This file contains tests for the functions, classes, and decorators
+in the split_args_for_inits module."""
+
+from python_template.utils import (
+    SplitInitMixin,
+    auto_split_init,
+    split_args_for_inits_strict_kwargs,
+)
+
+
+class A:  # pylint: disable=too-few-public-methods
+    """Test class A."""
+
+    def __init__(self, a1, a2=0, **kwargs):
+        print(f"A init: a1={a1}, a2={a2}, kwargs={kwargs}")
+        self.a1 = a1
+        self.a2 = a2
+
+
+class B:  # pylint: disable=too-few-public-methods
+    """Test class B."""
+
+    def __init__(self, b1, b2=0):
+        print(f"B init: b1={b1}, b2={b2}")
+        self.b1 = b1
+        self.b2 = b2
+
+
+class C(SplitInitMixin, A, B):  # pylint: disable=too-few-public-methods
+    """Test class C. For use of the mixin class."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        print(
+            f"C leftovers: {self._init_leftovers}"  # pylint: disable=no-member
+        )
+
+
+@auto_split_init
+class D(A, B):  # pylint: disable=too-few-public-methods
+    """Test class D. For use of the decorator."""
+
+    def __init__(
+        self, *args, **kwargs
+    ):  # pylint: disable=super-init-not-called,unused-argument
+        print(
+            f"D leftovers: {self._init_leftovers}"  # pylint: disable=no-member
+        )
+
+
+class E(A, B):  # pylint: disable=too-few-public-methods
+    """Test class E. For use of the function."""
+
+    def __init__(self, *args, **kwargs):
+        self.split = split_args_for_inits_strict_kwargs(
+            type(self), args, kwargs
+        )
+        A.__init__(self, *self.split[A]["args"], **self.split[A]["kwargs"])
+        B.__init__(self, *self.split[B]["args"], **self.split[B]["kwargs"])
+        print(f"E leftovers: {self.split['leftovers']}")
+
+
+def test_split_args_for_inits_strict_kwargs():
+    """Tests the split_args_for_inits_strict_kwargs function."""
+    # print("\n=== Function Test ===")
+    a1 = "a"
+    b1 = "b"
+    extra = 987
+    zero = 0
+    e = E(a1=a1, b1=b1, extra=extra)
+    # === Function Test ===
+    # A init: a1=a, a2=0, kwargs={}
+    # B init: b1=b, b2=0
+    # E leftovers: {'args': [], 'kwargs': {'extra': 987}}
+    assert e.a1 == a1
+    assert e.a2 == zero
+    assert e.b1 == b1
+    assert e.b2 == zero
+    assert e.split["leftovers"]["kwargs"]["extra"] == extra
+
+
+def test_split_init_mixin():
+    """Tests the SplitInitMixin class."""
+    a1 = "foo"
+    b1 = "bar"
+    extra = 123
+    zero = 0
+    # print("\n=== Mixin Test ===")
+    c = C(a1=a1, b1=b1, extra=extra)
+    # === Mixin Test ===
+    # A init: a1=foo, a2=0, kwargs={}
+    # B init: b1=bar, b2=0
+    # C leftovers: {'args': [], 'kwargs': {'extra': 123}}
+    assert c.a1 == a1
+    assert c.a2 == zero
+    assert c.b1 == b1
+    assert c.b2 == zero
+    # assert c.split["leftovers"]["kwargs"]["extra"] == extra
+
+
+def test_auto_split_init():
+    """Tests the auto_split_init decoarator."""
+    a1 = "x"
+    b1 = "y"
+    extra = 456
+    zero = 0
+    # print("\n=== Decorator Test ===")
+    d = D(a1=a1, b1=b1, extra=extra)
+    # === Decorator Test ===
+    # A init: a1=x, a2=0, kwargs={}
+    # B init: b1=y, b2=0
+    # D leftovers: {'args': [], 'kwargs': {'extra': 456}}
+    assert d.a1 == a1
+    assert d.a2 == zero
+    assert d.b1 == b1
+    assert d.b2 == zero
+    # assert d.split["leftovers"]["kwargs"]["extra"] == extra
+
+
+# if __name__ == "__main__":
+#     test_split_args_for_inits_strict_kwargs()
+#     test_split_init_mixin()
+#     test_auto_split_init()


### PR DESCRIPTION
Add function (and mixin and decorator) to split args for inits. 

Example:
```
    class Child(Parent1, Parent2):
        def __init__(self, *args, **kwargs):
            self.split = split_args_for_inits_strict_kwargs(
                type(self), args, kwargs
            )
            Parent1.__init__(
                self, *self.split[Parent1]["args"], **self.split[Parent1]["kwargs"]
            )
            Parent2.__init__(
                self, *self.split[Parent2]["args"], **self.split[Parent2]["kwargs"]
            )
            self._init_leftovers = self.split["leftovers"]
```